### PR TITLE
Fix server initialization

### DIFF
--- a/helpers/electron-window-state.js
+++ b/helpers/electron-window-state.js
@@ -151,9 +151,6 @@ module.exports = (options) => {
   }
 
   const manage = (win) => {
-    if (config.maximize && state.isMaximized) {
-      win.maximize()
-    }
     if (config.fullScreen && state.isFullScreen) {
       win.setFullScreen(true)
     }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const pathToLayoutExprPortReq = path.join(pathToLayouts, 'express-port-required.
 
 const serverPath = path.join(__dirname, 'server.js')
 let ipc = null
+let isMainWinMaximized = false
 
 const runServer = () => {
   ipc = fork(serverPath, [], {
@@ -77,16 +78,20 @@ const createWindow = (
     width: defaultWidth,
     height: defaultHeight
   } = workAreaSize
+  const isMainWindow = winName === 'mainWindow'
   const {
-    width,
-    height,
+    width = defaultWidth,
+    height = defaultHeight,
     x,
     y,
+    isMaximized,
     manage
-  } = windowStateKeeper({
-    defaultWidth,
-    defaultHeight
-  })
+  } = isMainWindow
+    ? windowStateKeeper({
+      defaultWidth,
+      defaultHeight
+    })
+    : {}
   const _props = {
     autoHideMenuBar: true,
     width,
@@ -141,7 +146,9 @@ const createWindow = (
     }
   })
 
-  if (winName === 'mainWindow') {
+  if (isMainWindow) {
+    isMainWinMaximized = isMaximized
+
     manage(wins[winName])
   }
 }
@@ -252,6 +259,10 @@ const initialize = () => {
 
         switch (mess.state) {
           case 'ready:server':
+            if (isMainWinMaximized) {
+              wins.mainWindow.maximize()
+            }
+
             wins.mainWindow.show()
 
             if (wins.loadingWindow) {


### PR DESCRIPTION
This PR fixes server initialization which is related to the non-triggering of the electron event `ready-to-show`. If the method `window.maximize()` is called, then `ready-to-show` event does not fire. It worked after the `maximize()` call was removed
https://github.com/electron/electron/issues/7779#issuecomment-463157343