### PR TITLE
Add two modal dialogs to show DB migration state

### DIFF
--- a/src/show-migrations-modal-dialog.js
+++ b/src/show-migrations-modal-dialog.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const wins = require('./windows')
+const showMessageModalDialog = require('./show-message-modal-dialog')
+
+module.exports = async (
+  isMigrationsError,
+  isMigrationsReady
+) => {
+  if (
+    !isMigrationsError &&
+    !isMigrationsReady
+  ) {
+    return
+  }
+
+  const type = isMigrationsError
+    ? 'error'
+    : 'info'
+  const message = isMigrationsError
+    ? 'DВ migration failed, all data has been deleted,\nsynchronization will start from scratch'
+    : 'DB migration completed successfully'
+  const buttons = isMigrationsError
+    ? ['Cancel']
+    : ['OK']
+
+  await showMessageModalDialog(
+    wins.mainWindow,
+    {
+      type,
+      message,
+      buttons,
+      defaultId: 0,
+      cancelId: 0
+    }
+  )
+}


### PR DESCRIPTION
This PR adds two modal dialogs to show DB migration state when a user import DB:
  - DВ migration failed
![Screenshot from 2019-11-27 10-05-27](https://user-images.githubusercontent.com/16489235/69706915-5d872980-1101-11ea-9ef4-37d5bebb7546.png)

  - DB migration completed
![Screenshot from 2019-11-27 10-06-48](https://user-images.githubusercontent.com/16489235/69706927-64ae3780-1101-11ea-887d-966a153f7ff2.png)


**Depends** on this PR: [bfx-reports-framework#62](https://github.com/bitfinexcom/bfx-reports-framework/pull/62)