### PR TITLE
 Add ability to store users csv path into json config

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "dependencies": {
     "archiver": "^3.1.1",
     "async": "^2.6.1",
-    "bittorrent-dht": "^8.4.0",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
+    "bittorrent-dht": "^8.4.0",
     "electron-serve": "0.2.0",
     "find-free-port": "^2.0.0",
     "grenache-grape": "^0.9.8",
+    "lodash": "^4.17.15",
     "yauzl": "^2.10.0"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -57,9 +57,10 @@ let isMigrationsError = false
       throw new WrongPathToUserCsvError()
     }
 
-    const pathToCsvFolder = process.platform === 'darwin'
-      ? path.join(pathToUserCsv, 'BitfinexReports')
-      : path.join(pathToUserCsv, 'csv')
+    const isRelativePath = pathToUserCsv.startsWith('..')
+    const pathToCsvFolder = isRelativePath
+      ? path.join(pathToUserCsv, 'csv')
+      : path.join(pathToUserCsv, 'BitfinexReports')
     const defaultPorts = getDefaultPorts()
     const {
       grape1DhtPort,

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ const {
 const {
   RunningExpressOnPortError,
   WrongPathToUserDataError,
-  WrongPathToUserDocumentsError,
+  WrongPathToUserCsvError,
   WrongSecretKeyError
 } = require('./src/errors')
 
@@ -44,7 +44,7 @@ let isMigrationsError = false
 ;(async () => {
   try {
     const pathToUserData = process.env.PATH_TO_USER_DATA
-    const pathToUserDocuments = process.env.PATH_TO_USER_DOCUMENTS
+    const pathToUserCsv = process.env.PATH_TO_USER_CSV
     const secretKey = process.env.SECRET_KEY
 
     if (!secretKey) {
@@ -53,13 +53,13 @@ let isMigrationsError = false
     if (!pathToUserData) {
       throw new WrongPathToUserDataError()
     }
-    if (!pathToUserDocuments) {
-      throw new WrongPathToUserDocumentsError()
+    if (!pathToUserCsv) {
+      throw new WrongPathToUserCsvError()
     }
 
     const pathToCsvFolder = process.platform === 'darwin'
-      ? path.join(pathToUserDocuments, 'BitfinexReports')
-      : '../../../csv'
+      ? path.join(pathToUserCsv, 'BitfinexReports')
+      : path.join(pathToUserCsv, 'csv')
     const defaultPorts = getDefaultPorts()
     const {
       grape1DhtPort,

--- a/server.js
+++ b/server.js
@@ -32,6 +32,7 @@ const {
 const {
   RunningExpressOnPortError,
   WrongPathToUserDataError,
+  WrongPathToUserDocumentsError,
   WrongSecretKeyError
 } = require('./src/errors')
 
@@ -43,6 +44,7 @@ let isMigrationsError = false
 ;(async () => {
   try {
     const pathToUserData = process.env.PATH_TO_USER_DATA
+    const pathToUserDocuments = process.env.PATH_TO_USER_DOCUMENTS
     const secretKey = process.env.SECRET_KEY
 
     if (!secretKey) {
@@ -51,10 +53,13 @@ let isMigrationsError = false
     if (!pathToUserData) {
       throw new WrongPathToUserDataError()
     }
+    if (!pathToUserDocuments) {
+      throw new WrongPathToUserDocumentsError()
+    }
 
     const pathToCsvFolder = process.platform === 'darwin'
-      ? pathToUserData
-      : '../../..'
+      ? path.join(pathToUserDocuments, 'BitfinexReports')
+      : '../../../csv'
     const defaultPorts = getDefaultPorts()
     const {
       grape1DhtPort,
@@ -114,7 +119,7 @@ let isMigrationsError = false
       '--isSchedulerEnabled=true',
       '--isElectronjsEnv=true',
       '--isLoggerDisabled=false',
-      `--csvFolder=${pathToCsvFolder}/csv`,
+      `--csvFolder=${pathToCsvFolder}`,
       `--tempFolder=${pathToUserData}/temp`,
       `--logsFolder=${pathToUserData}/logs`,
       `--dbFolder=${pathToUserData}`,

--- a/src/change-reports-folder.js
+++ b/src/change-reports-folder.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const electron = require('electron')
+
+const {
+  InvalidFilePathError,
+  ReportsFolderChangingError
+} = require('./errors')
+const showErrorModalDialog = require('./show-error-modal-dialog')
+const pauseApp = require('./pause-app')
+const relaunch = require('./relaunch')
+const { getConfigsKeeperByName } = require('./configs-keeper')
+
+module.exports = ({ pathToUserDocuments }) => {
+  const dialog = electron.dialog || electron.remote.dialog
+
+  return () => {
+    const win = electron.BrowserWindow.getFocusedWindow()
+
+    dialog.showOpenDialog(
+      win,
+      {
+        title: 'Change reports folder',
+        defaultPath: pathToUserDocuments,
+        buttonLabel: 'Select',
+        properties: [
+          'openDirectory',
+          'createDirectory',
+          'promptToCreate',
+          'treatPackageAsDirectory'
+        ]
+      },
+      async (files) => {
+        try {
+          if (
+            !Array.isArray(files) ||
+            files.length === 0
+          ) {
+            return
+          }
+          if (files.some(file => (
+            !file || typeof file !== 'string'
+          ))) {
+            throw new InvalidFilePathError()
+          }
+
+          await pauseApp()
+          const isSaved = await getConfigsKeeperByName('main')
+            .saveConfigs({ pathToUserCsv: files[0] })
+
+          if (!isSaved) {
+            throw new ReportsFolderChangingError()
+          }
+
+          relaunch()
+        } catch (err) {
+          await showErrorModalDialog(win, 'Change reports folder', err)
+
+          console.error(err)
+          relaunch()
+        }
+      }
+    )
+  }
+}

--- a/src/configs-keeper.js
+++ b/src/configs-keeper.js
@@ -1,0 +1,171 @@
+'use strict'
+
+const { promisify } = require('util')
+const path = require('path')
+const fs = require('fs')
+const { cloneDeep } = require('lodash')
+
+const {
+  writeFileSync,
+  mkdirSync,
+  accessSync,
+  constants: { F_OK, W_OK }
+} = fs
+const access = promisify(fs.access)
+const mkdir = promisify(fs.mkdir)
+const writeFile = promisify(fs.writeFile)
+
+const { CONFIGS_FILE_NAME } = require('./const')
+const {
+  WrongPathToUserDataError
+} = require('./errors')
+
+class ConfigsKeeper {
+  constructor (
+    {
+      pathToUserData,
+      configsFileName = CONFIGS_FILE_NAME
+    } = {},
+    configsByDefault
+  ) {
+    if (!pathToUserData) {
+      throw new WrongPathToUserDataError()
+    }
+
+    this.pathToUserData = pathToUserData
+    this.configsFileName = configsFileName
+    this.configsByDefault = configsByDefault
+
+    this.pathToConfigsFile = path.join(
+      this.pathToUserData,
+      this.configsFileName
+    )
+    this.configs = {
+      ...this.configsByDefault,
+      ...this._loadConfigs()
+    }
+
+    this.queue = []
+  }
+
+  _loadConfigs () {
+    try {
+      return require(this.pathToConfigsFile)
+    } catch (err) {}
+  }
+
+  getConfigs () {
+    return cloneDeep(this.configs)
+  }
+
+  getConfigByName (name) {
+    return (
+      this.configs[name] &&
+      typeof this.configs[name] === 'object'
+    )
+      ? cloneDeep(this.configs[name])
+      : this.configs[name]
+  }
+
+  setConfigs (configs) {
+    this.configs = {
+      ...this.configs,
+      ...configs
+    }
+
+    return this
+  }
+
+  async _process () {
+    for (const promise of [...this.queue]) {
+      await promise
+
+      this.queue.shift()
+    }
+  }
+
+  async _saveConfigs (configs) {
+    try {
+      await this._process()
+
+      const dir = path.dirname(this.pathToConfigsFile)
+
+      try {
+        await access(dir, F_OK | W_OK)
+      } catch (err) {
+        await mkdir(dir, { recursive: true })
+      }
+
+      const _configs = this
+        .setConfigs(configs)
+        .getConfigs()
+
+      await writeFile(
+        this.pathToConfigsFile,
+        JSON.stringify(_configs)
+      )
+
+      return true
+    } catch (err) {
+      console.error(err)
+
+      return false
+    }
+  }
+
+  async saveConfigs (configs) {
+    const task = this._saveConfigs(configs)
+    this.queue.push(task)
+
+    const res = await task
+
+    return res
+  }
+
+  saveConfigsSync (configs) {
+    try {
+      const dir = path.dirname(this.pathToConfigsFile)
+
+      try {
+        accessSync(dir, F_OK | W_OK)
+      } catch (err) {
+        mkdirSync(dir, { recursive: true })
+      }
+
+      const _configs = this
+        .setConfigs(configs)
+        .getConfigs()
+
+      writeFileSync(
+        this.pathToConfigsFile,
+        JSON.stringify(_configs)
+      )
+
+      return true
+    } catch (err) {
+      console.error(err)
+
+      return false
+    }
+  }
+}
+
+module.exports = {
+  configsKeeperFactory: (
+    opts = {},
+    configsByDefault
+  ) => {
+    const {
+      configsKeeperName = 'main'
+    } = opts
+
+    const configsKeeper = new ConfigsKeeper(
+      opts,
+      configsByDefault
+    )
+    this[configsKeeperName] = configsKeeper
+
+    return configsKeeper
+  },
+  getConfigsKeeperByName: (name) => this[name]
+}

--- a/src/const.js
+++ b/src/const.js
@@ -1,10 +1,12 @@
 'use strict'
 
+const CONFIGS_FILE_NAME = 'bfx-report-configs.json'
 const DEFAULT_ARCHIVE_DB_FILE_NAME = 'bfx-report-db-archive'
 const DB_FILE_NAME = 'db-sqlite_sync_m0.db'
 const SECRET_KEY_FILE_NAME = 'secret-key'
 
 module.exports = {
+  CONFIGS_FILE_NAME,
   DEFAULT_ARCHIVE_DB_FILE_NAME,
   DB_FILE_NAME,
   SECRET_KEY_FILE_NAME

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -22,7 +22,7 @@ module.exports = ({
         { type: 'separator' },
         {
           label: 'Open dev tools',
-          accelerator: 'CmdOrCtrl+D',
+          accelerator: 'CmdOrCtrl+T',
           click: () => {
             if (!wins.mainWindow) {
               return
@@ -71,7 +71,7 @@ module.exports = ({
         },
         {
           label: 'Remove DB',
-          accelerator: 'CmdOrCtrl+R',
+          accelerator: 'CmdOrCtrl+D',
           click: removeDB({ pathToUserData })
         },
         {

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -9,7 +9,10 @@ const exportDB = require('./export-db')
 const importDB = require('./import-db')
 const removeDB = require('./remove-db')
 
-module.exports = ({ pathToUserData }) => {
+module.exports = ({
+  pathToUserData,
+  pathToUserDocuments
+}) => {
   const menuTemplate = [
     {
       label: 'Application',
@@ -58,12 +61,12 @@ module.exports = ({ pathToUserData }) => {
         {
           label: 'Export DB',
           accelerator: 'CmdOrCtrl+E',
-          click: exportDB({ pathToUserData })
+          click: exportDB({ pathToUserData, pathToUserDocuments })
         },
         {
           label: 'Import DB',
           accelerator: 'CmdOrCtrl+I',
-          click: importDB({ pathToUserData })
+          click: importDB({ pathToUserData, pathToUserDocuments })
         },
         {
           label: 'Remove DB',

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -8,6 +8,7 @@ const wins = require('./windows')
 const exportDB = require('./export-db')
 const importDB = require('./import-db')
 const removeDB = require('./remove-db')
+const changeReportsFolder = require('./change-reports-folder')
 
 module.exports = ({
   pathToUserData,
@@ -72,6 +73,11 @@ module.exports = ({
           label: 'Remove DB',
           accelerator: 'CmdOrCtrl+R',
           click: removeDB({ pathToUserData })
+        },
+        {
+          label: 'Change reports folder',
+          accelerator: 'CmdOrCtrl+F',
+          click: changeReportsFolder({ pathToUserDocuments })
         }
       ]
     }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -71,8 +71,8 @@ class WrongPathToUserDataError extends BaseError {
   }
 }
 
-class WrongPathToUserDocumentsError extends BaseError {
-  constructor (message = 'ERR_WRONG_PATH_TO_USER_DOCUMENTS') {
+class WrongPathToUserCsvError extends BaseError {
+  constructor (message = 'ERR_WRONG_PATH_TO_USER_CSV') {
     super(message)
   }
 }
@@ -95,6 +95,6 @@ module.exports = {
   AppInitializationError,
   FreePortError,
   WrongPathToUserDataError,
-  WrongPathToUserDocumentsError,
+  WrongPathToUserCsvError,
   WrongSecretKeyError
 }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -83,6 +83,12 @@ class WrongSecretKeyError extends BaseError {
   }
 }
 
+class ReportsFolderChangingError extends BaseError {
+  constructor (message = 'ERR_REPORTS_FOLDER_HAS_NOT_CHANGED') {
+    super(message)
+  }
+}
+
 module.exports = {
   BaseError,
   InvalidFilePathError,
@@ -96,5 +102,6 @@ module.exports = {
   FreePortError,
   WrongPathToUserDataError,
   WrongPathToUserCsvError,
-  WrongSecretKeyError
+  WrongSecretKeyError,
+  ReportsFolderChangingError
 }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -71,6 +71,12 @@ class WrongPathToUserDataError extends BaseError {
   }
 }
 
+class WrongPathToUserDocumentsError extends BaseError {
+  constructor (message = 'ERR_WRONG_PATH_TO_USER_DOCUMENTS') {
+    super(message)
+  }
+}
+
 class WrongSecretKeyError extends BaseError {
   constructor (message = 'ERR_WRONG_SECRET_KEY') {
     super(message)
@@ -89,5 +95,6 @@ module.exports = {
   AppInitializationError,
   FreePortError,
   WrongPathToUserDataError,
+  WrongPathToUserDocumentsError,
   WrongSecretKeyError
 }

--- a/src/export-db.js
+++ b/src/export-db.js
@@ -17,17 +17,20 @@ const {
   SECRET_KEY_FILE_NAME
 } = require('./const')
 
-module.exports = ({ pathToUserData }) => {
-  const dbPath = path.join(pathToUserData, DB_FILE_NAME)
-  const secretKeyPath = path.join(pathToUserData, SECRET_KEY_FILE_NAME)
+module.exports = ({
+  pathToUserData,
+  pathToUserDocuments
+}) => {
   const dialog = electron.dialog || electron.remote.dialog
-  const app = electron.app || electron.remote.app
+
   const _timestamp = (new Date()).toISOString().split('.')[0]
   const timestamp = _timestamp.replace(/[:]/g, '-')
   const defaultPath = path.join(
-    app.getPath('documents'),
+    pathToUserDocuments,
     `${DEFAULT_ARCHIVE_DB_FILE_NAME}-${timestamp}`
   )
+  const dbPath = path.join(pathToUserData, DB_FILE_NAME)
+  const secretKeyPath = path.join(pathToUserData, SECRET_KEY_FILE_NAME)
 
   return () => {
     const win = electron.BrowserWindow.getFocusedWindow()

--- a/src/import-db.js
+++ b/src/import-db.js
@@ -32,9 +32,11 @@ const _rmDbExcludeMain = async (folderPath, dbFileName) => {
   }
 }
 
-module.exports = ({ pathToUserData }) => {
+module.exports = ({
+  pathToUserData,
+  pathToUserDocuments
+}) => {
   const dialog = electron.dialog || electron.remote.dialog
-  const app = electron.app || electron.remote.app
 
   return () => {
     const win = electron.BrowserWindow.getFocusedWindow()
@@ -43,7 +45,7 @@ module.exports = ({ pathToUserData }) => {
       win,
       {
         title: 'Database import',
-        defaultPath: app.getPath('documents'),
+        defaultPath: pathToUserDocuments,
         buttonLabel: 'Import',
         properties: [
           'openFile',

--- a/src/import-db.js
+++ b/src/import-db.js
@@ -77,7 +77,7 @@ module.exports = ({
           )
 
           if (extractedfileNames.every(file => file !== DB_FILE_NAME)) {
-            throw new DbImportingError(DbImportingError)
+            throw new DbImportingError()
           }
 
           relaunch()

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -63,12 +63,21 @@ module.exports = () => {
     app.on('ready', async () => {
       try {
         const pathToUserData = app.getPath('userData')
+        const pathToUserDocuments = app.getPath('documents')
+
         const secretKey = await makeOrReadSecretKey(
           { pathToUserData }
         )
 
-        await createMainWindow({ pathToUserData })
-        runServer({ pathToUserData, secretKey })
+        await createMainWindow({
+          pathToUserData,
+          pathToUserDocuments
+        })
+        runServer({
+          pathToUserData,
+          pathToUserDocuments,
+          secretKey
+        })
 
         const mess = await _ipcMessToPromise(ipcs.serverIpc)
         const {

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -21,6 +21,9 @@ const showMigrationsModalDialog = require(
 )
 const makeOrReadSecretKey = require('./make-or-read-secret-key')
 const {
+  configsKeeperFactory
+} = require('./configs-keeper')
+const {
   RunningExpressOnPortError,
   IpcMessageError,
   AppInitializationError
@@ -65,6 +68,14 @@ module.exports = () => {
         const pathToUserData = app.getPath('userData')
         const pathToUserDocuments = app.getPath('documents')
 
+        configsKeeperFactory(
+          { pathToUserData },
+          {
+            pathToUserCsv: process.platform === 'darwin'
+              ? pathToUserDocuments
+              : '../../../..'
+          }
+        )
         const secretKey = await makeOrReadSecretKey(
           { pathToUserData }
         )
@@ -75,7 +86,6 @@ module.exports = () => {
         })
         runServer({
           pathToUserData,
-          pathToUserDocuments,
           secretKey
         })
 

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -73,7 +73,7 @@ module.exports = () => {
           {
             pathToUserCsv: process.platform === 'darwin'
               ? pathToUserDocuments
-              : '../../../..'
+              : '../../..'
           }
         )
         const secretKey = await makeOrReadSecretKey(

--- a/src/run-server.js
+++ b/src/run-server.js
@@ -7,11 +7,16 @@ const ipcs = require('./ipcs')
 
 const serverPath = path.join(__dirname, '../server.js')
 
-module.exports = ({ pathToUserData, secretKey }) => {
+module.exports = ({
+  pathToUserData,
+  pathToUserDocuments,
+  secretKey
+}) => {
   const env = {
     ...process.env,
     ELECTRON_VERSION: process.versions.electron,
     PATH_TO_USER_DATA: pathToUserData,
+    PATH_TO_USER_DOCUMENTS: pathToUserDocuments,
     SECRET_KEY: secretKey
   }
   const ipc = fork(serverPath, [], {

--- a/src/run-server.js
+++ b/src/run-server.js
@@ -4,19 +4,20 @@ const { fork } = require('child_process')
 const path = require('path')
 
 const ipcs = require('./ipcs')
+const { getConfigsKeeperByName } = require('./configs-keeper')
 
 const serverPath = path.join(__dirname, '../server.js')
 
 module.exports = ({
   pathToUserData,
-  pathToUserDocuments,
   secretKey
 }) => {
   const env = {
     ...process.env,
     ELECTRON_VERSION: process.versions.electron,
     PATH_TO_USER_DATA: pathToUserData,
-    PATH_TO_USER_DOCUMENTS: pathToUserDocuments,
+    PATH_TO_USER_CSV: getConfigsKeeperByName('main')
+      .getConfigByName('pathToUserCsv'),
     SECRET_KEY: secretKey
   }
   const ipc = fork(serverPath, [], {

--- a/src/show-error-modal-dialog.js
+++ b/src/show-error-modal-dialog.js
@@ -5,7 +5,8 @@ const {
   InvalidFileNameInArchiveError,
   DbImportingError,
   DbRemovingError,
-  InvalidFolderPathError
+  InvalidFolderPathError,
+  ReportsFolderChangingError
 } = require('./errors')
 const showMessageModalDialog = require('./show-message-modal-dialog')
 
@@ -57,6 +58,11 @@ module.exports = (win, title = 'Error', err) => {
   }
   if (err instanceof DbRemovingError) {
     const message = 'The database has not removed'
+
+    return _showErrorBox(win, title, message)
+  }
+  if (err instanceof ReportsFolderChangingError) {
+    const message = 'The reports folder has not changed'
 
     return _showErrorBox(win, title, message)
   }

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -24,9 +24,8 @@ const _createWindow = (
   cb,
   {
     pathname = null,
-    winName = 'mainWindow',
-    pathToUserData
-  },
+    winName = 'mainWindow'
+  } = {},
   props = {}
 ) => {
   const point = electron.screen.getCursorScreenPoint()
@@ -49,8 +48,7 @@ const _createWindow = (
   } = isMainWindow
     ? windowStateKeeper({
       defaultWidth,
-      defaultHeight,
-      path: pathToUserData
+      defaultHeight
     })
     : {}
   const _props = {
@@ -177,8 +175,7 @@ const createMainWindow = ({
 
           createMenu({ pathToUserData, pathToUserDocuments })
           resolve()
-        },
-        { pathToUserData }
+        }
       )
     } catch (err) {
       reject(err)

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -163,7 +163,10 @@ const _createChildWindow = (
   })
 }
 
-const createMainWindow = ({ pathToUserData }) => {
+const createMainWindow = ({
+  pathToUserData,
+  pathToUserDocuments
+}) => {
   return new Promise((resolve, reject) => {
     try {
       _createWindow(
@@ -172,7 +175,7 @@ const createMainWindow = ({ pathToUserData }) => {
             wins.mainWindow.webContents.openDevTools()
           }
 
-          createMenu({ pathToUserData })
+          createMenu({ pathToUserData, pathToUserDocuments })
           resolve()
         },
         { pathToUserData }


### PR DESCRIPTION
This PR adds an ability to store users csv path into json config. Basic changes:
  - store users csv path into json config
  - add ability to change reports folder via the menu bar option `Tools` -> `Change reports folder`
  - fix menu bar hotkeys
  - set csv folder by default on mac `Documents/BitfinexReports`, on linux and win `csv` folder in the root of the app

![Screenshot from 2020-06-01 18-36-10](https://user-images.githubusercontent.com/16489235/83739952-e78aee80-a65e-11ea-98de-62a809ce11b8.png)


**Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report-electron/pull/39