### PR TITLE
Fix the electron launcher issue for Ubuntu 20.X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/*
 package-lock.json
 .env
 lastCommit.json
+build/linux-launcher/launcher
+build/linux-launcher/*.o

--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 Already complied binaries can be found on release section [release section](https://github.com/bitfinexcom/bfx-report-electron/releases). </br>
 Download the correspondent binary according your operating system.</br>
 
-> To launch on Linux needs double click by `Bitfinex Report.desktop` file in the root of the release directory and confirm that the application is from the trusted source. **Important**: The path to the application folder should not have spaces!
-
 ## Setup
 
 ### Install

--- a/build/linux-launcher/Bitfinex Report.desktop
+++ b/build/linux-launcher/Bitfinex Report.desktop
@@ -1,9 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Name=Bitfinex Report
-Exec=sh -c "`dirname %k`/launcher.sh `dirname %k`"
-Icon=application-x-executable
-Terminal=false
-Type=Application
-Categories=Network;
-Name[en_US]=Bitfinex Report

--- a/build/linux-launcher/Makefile
+++ b/build/linux-launcher/Makefile
@@ -1,0 +1,28 @@
+VERBOSE = TRUE
+
+TARGET := launcher
+OBJECTS := $(TARGET).o
+
+CC := gcc
+CFLAGS := -g -Wall -no-pie
+LIBS := 
+
+RM := rm -rf
+ERRIGNORE := 2>/dev/null
+
+ifeq ($(VERBOSE),TRUE)
+	HIDE :=
+else
+	HIDE := @
+endif
+
+all: cleanExe $(TARGET) clean
+
+$(TARGET): $(OBJECTS)
+	$(HIDE)$(CC) $(CFLAGS) -o $@ $(OBJECTS) $(LIBS)
+
+cleanExe:
+	$(HIDE)$(RM) $(TARGET) $(ERRIGNORE)
+
+clean:
+	$(HIDE)$(RM) *.o $(ERRIGNORE)

--- a/build/linux-launcher/launcher.c
+++ b/build/linux-launcher/launcher.c
@@ -1,8 +1,34 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
 
-int main(void) {
-  system("./launcher.sh");
+void msgBox(char *s){
+  char cmd[1024];
+  sprintf(cmd, "./msg-box.sh \"%s\"", s);
 
-  return 0;
+  int state = system(cmd);
+
+  if (state) {
+    system("zenity --error --ellipsize --text=\"Error with msg-box.sh\"");
+  }
+}
+
+int main(int argc, char *argv[]) {
+  errno = 0;
+
+  char *programName = "./launcher.sh";
+  char *args[] = { programName, NULL };
+ 
+  execvp(programName, args);
+  perror(programName);
+  
+  char *errMess = strerror(errno);
+  char mess[1024];
+
+  sprintf(mess, "%s: %s", programName, errMess);
+  msgBox(mess);
+
+  exit(1);
 }

--- a/build/linux-launcher/launcher.c
+++ b/build/linux-launcher/launcher.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(void) {
+  system("./launcher.sh");
+
+  return 0;
+}

--- a/build/linux-launcher/launcher.sh
+++ b/build/linux-launcher/launcher.sh
@@ -7,19 +7,12 @@ if [ ! -z "$1" ]; then
 fi
 
 appFilePath="$ROOT/app"
-desktopFilePath="$ROOT/Bitfinex Report.desktop"
-iconPath="$ROOT/resources/app/build/icon.png"
-
-bakDesktopFilePath="$desktopFilePath-bak"
 logFilePath="$ROOT/error.log"
 
-{
-  cp "$desktopFilePath" "$bakDesktopFilePath" \
-  && sed -i -e "s,Exec=.*,Exec=\"$ROOT/launcher.sh\" \"$ROOT\",g" "$desktopFilePath" \
-  && sed -i -e "s,Icon=.*,Icon=$iconPath,g" "$desktopFilePath" \
-  && rm -f "$bakDesktopFilePath"
-} || {
-  echo "Error setting icon path">>"$logFilePath"
-}
+output=$("$appFilePath" 2>&1)
+mess=$(echo "$output" | grep -v WARNING)
 
-appFilePath 2>>"$logFilePath"
+if [ "$mess" != "" ]; then
+  echo $mess>>"$logFilePath"
+  ./msg-box.sh "$mess"
+fi

--- a/build/linux-launcher/launcher.sh
+++ b/build/linux-launcher/launcher.sh
@@ -6,18 +6,20 @@ if [ ! -z "$1" ]; then
   ROOT=$1
 fi
 
-desktopFilePath="Bitfinex Report.desktop"
-bakDesktopFilePath="$desktopFilePath-bak"
+appFilePath="$ROOT/app"
+desktopFilePath="$ROOT/Bitfinex Report.desktop"
 iconPath="$ROOT/resources/app/build/icon.png"
+
+bakDesktopFilePath="$desktopFilePath-bak"
 logFilePath="$ROOT/error.log"
 
 {
-  cp "$ROOT/$desktopFilePath" "$ROOT/$bakDesktopFilePath" \
-  && sed -i -e "s,Icon=.*,Icon=$iconPath,g" "$ROOT/$desktopFilePath" \
-  && rm -f "$ROOT/$bakDesktopFilePath"
+  cp "$desktopFilePath" "$bakDesktopFilePath" \
+  && sed -i -e "s,Exec=.*,Exec=\"$ROOT/launcher.sh\" \"$ROOT\",g" "$desktopFilePath" \
+  && sed -i -e "s,Icon=.*,Icon=$iconPath,g" "$desktopFilePath" \
+  && rm -f "$bakDesktopFilePath"
 } || {
   echo "Error setting icon path">>"$logFilePath"
 }
 
-cd "$ROOT"
-./app 2>>"$logFilePath"
+appFilePath 2>>"$logFilePath"

--- a/build/linux-launcher/msg-box.sh
+++ b/build/linux-launcher/msg-box.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+mess=""
+
+if [ $# -ge 1 ]
+then
+  mess=$1
+else
+  exit 0
+fi
+
+zenity \
+  --error \
+  --width=600\
+  --ok-label="OK" \
+  --title="Error of Bitfinex Report" \
+  --text="$mess" \
+  2>/dev/null

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -169,18 +169,18 @@ if [ $isNotSkippedReiDeps != 0 ]; then
       make -C $linuxLauncherFolder
 
       cp -f \
-        "$linuxLauncherFolder/Bitfinex Report.desktop" \
-        "Bitfinex Report.desktop"
-      cp -f \
         "$linuxLauncherFolder/launcher" \
         "Bitfinex Report"
       cp -f \
         "$linuxLauncherFolder/launcher.sh" \
         "launcher.sh"
+      cp -f \
+        "$linuxLauncherFolder/msg-box.sh" \
+        "msg-box.sh"
 
-      chmod +x "Bitfinex Report.desktop"
       chmod +x "Bitfinex Report"
       chmod +x "launcher.sh"
+      chmod +x "msg-box.sh"
     fi
 
     7z a -tzip $zipFile . -mmt | grep -v "Compressing"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -59,6 +59,8 @@ fi
 frontendFolder="$ROOT/bfx-report-ui"
 expressFolder="$frontendFolder/bfx-report-express"
 backendFolder="$ROOT/bfx-reports-framework"
+
+linuxLauncherFolder="$ROOT/build/linux-launcher"
 uiBuildFolder=/ui-build
 uiReadyFile="$uiBuildFolder/READY"
 
@@ -163,13 +165,21 @@ if [ $isNotSkippedReiDeps != 0 ]; then
 
     if [ $targetPlatform == "linux" ]
     then
+      # Build C executable launcher file
+      make -C $linuxLauncherFolder
+
       cp -f \
-        "$ROOT/build/linux-launcher/Bitfinex Report.desktop" \
+        "$linuxLauncherFolder/Bitfinex Report.desktop" \
         "Bitfinex Report.desktop"
       cp -f \
-        "$ROOT/build/linux-launcher/launcher.sh" \
+        "$linuxLauncherFolder/launcher" \
+        "Bitfinex Report"
+      cp -f \
+        "$linuxLauncherFolder/launcher.sh" \
         "launcher.sh"
+
       chmod +x "Bitfinex Report.desktop"
+      chmod +x "Bitfinex Report"
       chmod +x "launcher.sh"
     fi
 


### PR DESCRIPTION
This PR fixes the electron launcher issue for `Ubuntu 20.X`.

This issue came from updating electron from `v4.0.0` and above. The upstream changed their build process and changed the binary format from `ELF` to `PIE`, related issue https://github.com/electron/electron/issues/15406 
File managers utilize the file command to decide what to do with a file (e.g. open an image viewer, a text editor or execute the file). The file cannot distinguish between shared libraries and PIE executables and therefore misclassifies `PIE` files (see the corresponding [bug report](https://bugs.launchpad.net/ubuntu/+source/file/+bug/1747711)).
In this https://github.com/bitfinexcom/bfx-report-electron/pull/56 PR was decided to apply the solution to use `.desktop` file.
According to a code [commit](https://gitlab.gnome.org/GNOME/nautilus/commit/3a22ed5b8e3bbc1c59ff3069ee79755168754916) on Gitlab the famous file manager is set to lose the ability to run binaries and launch apps directly. Or, to put it another way, you won’t be able to double-click on programs, scripts or apps to launch them using Nautilus. This change affects to program shortcuts `.desktop`

As solution adds an ability to build a simple `C` executable launcher using `-no-pie` flag to launch the bash script `launcher.sh` which manage launching the electron app. That executable launcher binary put into root dir of Linux release and called `Bitfinex Report` and can be launched by double click
Also, there was fixed the issue related to spaces in the path to the app
The solution tested on Ubuntu v18 and v20