### PR TITLE
Add auto-update for linux

### DIFF
--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -8,6 +8,7 @@ RUN ./scripts/install-nodejs.sh $NODE_VERSION \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
     p7zip-full \
+    bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.mac-builder
+++ b/Dockerfile.mac-builder
@@ -8,6 +8,7 @@ RUN ./scripts/install-nodejs.sh $NODE_VERSION \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
     p7zip-full \
+    bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -10,6 +10,7 @@ RUN  ./scripts/install-nodejs.sh $NODE_VERSION \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
     p7zip-full \
+    bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/build/linux-launcher/launcher.sh
+++ b/build/linux-launcher/launcher.sh
@@ -10,7 +10,7 @@ appFilePath="$ROOT/app"
 logFilePath="$ROOT/error.log"
 
 output=$("$appFilePath" 2>&1)
-mess=$(echo "$output" | grep -v WARNING | grep -v electron\/issues\/23506)
+mess=$(echo "$output" | grep -v WARNING | grep -v electron\/issues\/23506 | grep -v Cannot\ download\ differentially)
 
 if [ "$mess" != "" ]; then
   echo $mess>>"$logFilePath"

--- a/build/linux-launcher/launcher.sh
+++ b/build/linux-launcher/launcher.sh
@@ -10,7 +10,7 @@ appFilePath="$ROOT/app"
 logFilePath="$ROOT/error.log"
 
 output=$("$appFilePath" 2>&1)
-mess=$(echo "$output" | grep -v WARNING)
+mess=$(echo "$output" | grep -v WARNING | grep -v electron\/issues\/23506)
 
 if [ "$mess" != "" ]; then
   echo $mess>>"$logFilePath"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "electron": "11.4.1",
     "electron-builder": "22.10.5",
+    "js-yaml": "^4.0.0",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",
     "standard": "^14.3.1"

--- a/package.json
+++ b/package.json
@@ -49,15 +49,14 @@
     "test": "standard"
   },
   "build": {
-    "publish": [
-      {
-        "provider": "github",
-        "repo": "bfx-report-electron",
-        "owner": "bitfinexcom",
-        "channel": "latest",
-        "useMultipleRangeRequest": false
-      }
-    ],
+    "publish": {
+      "provider": "github",
+      "repo": "bfx-report-electron",
+      "owner": "bitfinexcom",
+      "channel": "latest",
+      "useMultipleRangeRequest": false,
+      "updaterCacheDirName": "bfx-report-electron-updater"
+    },
     "npmRebuild": false,
     "extends": null,
     "asar": false,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "yauzl": "^2.10.0"
   },
   "devDependencies": {
-    "electron": "11.4.1",
+    "electron": "11.4.2",
     "electron-builder": "22.10.5",
     "js-yaml": "^4.0.0",
     "node-gyp": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -194,7 +194,8 @@
       "maintainer": "<bitfinex.com>",
       "category": "Network",
       "target": [
-        "dir"
+        "dir",
+        "AppImage"
       ]
     },
     "win": {

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -6,6 +6,7 @@ ROOT="$PWD"
 branch=master
 dbDriver=better-sqlite
 lastCommitFileName=lastCommit.json
+isZipReleaseFile="isZipRelease"
 
 source $ROOT/scripts/get-conf-value.sh
 source $ROOT/scripts/escape-string.sh
@@ -193,6 +194,8 @@ if [ $isNotSkippedReiDeps != 0 ]; then
       cp -f \
         "$linuxLauncherFolder/msg-box.sh" \
         "msg-box.sh"
+
+      touch "$isZipReleaseFile"
 
       chmod +x "Bitfinex Report"
       chmod +x "launcher.sh"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -196,6 +196,7 @@ if [ $isNotSkippedReiDeps != 0 ]; then
         "msg-box.sh"
 
       touch "$isZipReleaseFile"
+      node $ROOT/scripts/node/make-app-update-yml.js "$unpackedFolder"
 
       chmod +x "Bitfinex Report"
       chmod +x "launcher.sh"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -207,12 +207,19 @@ if [ $isNotSkippedReiDeps != 0 ]; then
 
     if [ $targetPlatform == "win" ]
     then
-      exeFile="/dist/$artifactName.exe"
-      blockmapFile="$exeFile.blockmap"
+      appFile="/dist/$artifactName.exe"
+      blockmapFile="$appFile.blockmap"
       latestYmlFile="/dist/latest.yml"
-      mv -f ./dist/*$targetPlatform*.exe "$exeFile"
+      mv -f ./dist/*$targetPlatform*.exe "$appFile"
       mv -f ./dist/*$targetPlatform*.exe.blockmap "$blockmapFile"
       mv -f ./dist/latest.yml "$latestYmlFile"
+    fi
+    if [ $targetPlatform == "linux" ]
+    then
+      appFile="/dist/$artifactName.AppImage"
+      latestYmlFile="/dist/latest-linux.yml"
+      mv -f ./dist/*$targetPlatform*.AppImage "$appFile"
+      mv -f ./dist/latest-linux.yml "$latestYmlFile"
     fi
 
     chmod -R a+xwr /dist 2>/dev/null

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -223,6 +223,8 @@ if [ $isNotSkippedReiDeps != 0 ]; then
       latestYmlFile="/dist/latest-linux.yml"
       mv -f ./dist/*$targetPlatform*.AppImage "$appFile"
       mv -f ./dist/latest-linux.yml "$latestYmlFile"
+
+      chmod a+x "$appFile"
     fi
 
     chmod -R a+xwr /dist 2>/dev/null

--- a/scripts/node/make-app-update-yml.js
+++ b/scripts/node/make-app-update-yml.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const yaml = require('js-yaml')
+
+const appDir = path.join(
+  path.dirname(require.main.filename),
+  '../..'
+)
+const {
+  build: { publish }
+} = require(path.join(appDir, 'package.json'))
+const unpackedFolder = process.argv[2]
+
+if (
+  !publish ||
+  typeof publish !== 'object' ||
+  !unpackedFolder ||
+  typeof unpackedFolder !== 'string'
+) {
+  process.exit(1)
+}
+
+const ymlName = 'app-update.yml'
+const ymlPath = path.join(
+  unpackedFolder,
+  'resources',
+  ymlName
+)
+
+const yamlStr = yaml.dump(publish, {
+  lineWidth: 8000
+})
+
+fs.writeFileSync(ymlPath, yamlStr)

--- a/src/auto-updater/bfx.appimage.updater.js
+++ b/src/auto-updater/bfx.appimage.updater.js
@@ -12,6 +12,11 @@ const {
   version
 } = require(path.join(appDir, 'package.json'))
 
+process.env.APPIMAGE = path.join(
+  path.join(appDir, '../../..'),
+  `BitfinexReport-${version}-x64-linux.AppImage`
+)
+
 const isZipRelease = (root) => {
   const isZipReleaseFile = path.join(root, 'isZipRelease')
 

--- a/src/auto-updater/bfx.appimage.updater.js
+++ b/src/auto-updater/bfx.appimage.updater.js
@@ -1,0 +1,54 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const {
+  AppImageUpdater
+} = require('electron-updater')
+const log = require('electron-log')
+
+const appDir = path.dirname(require.main.filename)
+const {
+  version
+} = require(path.join(appDir, 'package.json'))
+
+const isZipRelease = (root) => {
+  const isZipReleaseFile = path.join(root, 'isZipRelease')
+
+  return fs.existsSync(isZipReleaseFile)
+}
+
+const makeTempReleaseFile = (root) => {
+  const fileName = `BitfinexReport-${version}-x64-linux.AppImage`
+  const filePath = path.join(root, '..', fileName)
+
+  fs.writeFileSync(filePath, '')
+
+  return filePath
+}
+
+const prepareInstall = () => {
+  const root = path.join(appDir, '../..')
+
+  if (!isZipRelease(root)) {
+    return
+  }
+
+  try {
+    fs.rmdirSync(root, { recursive: true })
+  } catch (err) {
+    log.error(err)
+  }
+
+  process.env.APPIMAGE = makeTempReleaseFile(root)
+}
+
+class BfxAppImageUpdater extends AppImageUpdater {
+  doInstall (...args) {
+    prepareInstall()
+
+    return super.doInstall(...args)
+  }
+}
+
+module.exports = BfxAppImageUpdater

--- a/src/auto-updater/bfx.appimage.updater.js
+++ b/src/auto-updater/bfx.appimage.updater.js
@@ -12,15 +12,20 @@ const {
   version
 } = require(path.join(appDir, 'package.json'))
 
-process.env.APPIMAGE = path.join(
-  path.join(appDir, '../../..'),
-  `BitfinexReport-${version}-x64-linux.AppImage`
-)
-
 const isZipRelease = (root) => {
   const isZipReleaseFile = path.join(root, 'isZipRelease')
 
   return fs.existsSync(isZipReleaseFile)
+}
+
+const root = path.join(appDir, '../..')
+
+if (isZipRelease(root)) {
+  process.env.APPIMAGE = path.join(
+    root,
+    '..',
+    `BitfinexReport-${version}-x64-linux.AppImage`
+  )
 }
 
 const makeTempReleaseFile = (root) => {

--- a/src/auto-updater/bfx.appimage.updater.js
+++ b/src/auto-updater/bfx.appimage.updater.js
@@ -19,9 +19,7 @@ class BfxAppImageUpdater extends AppImageUpdater {
     const root = prepareInstall()
     const res = super.doInstall({
       ...opts,
-      isForceRunAfter: root
-        ? false
-        : opts.isForceRunAfter
+      isForceRunAfter: !root
     })
 
     if (!root) {

--- a/src/auto-updater/bfx.appimage.updater.js
+++ b/src/auto-updater/bfx.appimage.updater.js
@@ -1,57 +1,15 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
 const {
   AppImageUpdater
 } = require('electron-updater')
-const log = require('electron-log')
 
-const appDir = path.dirname(require.main.filename)
 const {
-  version
-} = require(path.join(appDir, 'package.json'))
+  prepareInstall,
+  setAppImagePathIfZipRelease
+} = require('./utils')
 
-const isZipRelease = (root) => {
-  const isZipReleaseFile = path.join(root, 'isZipRelease')
-
-  return fs.existsSync(isZipReleaseFile)
-}
-
-const root = path.join(appDir, '../..')
-
-if (isZipRelease(root)) {
-  process.env.APPIMAGE = path.join(
-    root,
-    '..',
-    `BitfinexReport-${version}-x64-linux.AppImage`
-  )
-}
-
-const makeTempReleaseFile = (root) => {
-  const fileName = `BitfinexReport-${version}-x64-linux.AppImage`
-  const filePath = path.join(root, '..', fileName)
-
-  fs.writeFileSync(filePath, '')
-
-  return filePath
-}
-
-const prepareInstall = () => {
-  const root = path.join(appDir, '../..')
-
-  if (!isZipRelease(root)) {
-    return
-  }
-
-  try {
-    fs.rmdirSync(root, { recursive: true })
-  } catch (err) {
-    log.error(err)
-  }
-
-  process.env.APPIMAGE = makeTempReleaseFile(root)
-}
+setAppImagePathIfZipRelease()
 
 class BfxAppImageUpdater extends AppImageUpdater {
   doInstall (...args) {

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -359,6 +359,7 @@ const _autoUpdaterFactory = () => {
 
   autoUpdater.autoDownload = false
   autoUpdater.logger = log
+  autoUpdater.logger.transports.console.level = 'warn'
   autoUpdater.logger.transports.file.level = 'info'
 
   _reinitInterval()

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -366,9 +366,12 @@ const _autoUpdaterFactory = () => {
   return autoUpdater
 }
 
-// TODO: don't support update for linux and mac right now
+// TODO: don't support update for mac right now
 const checkForUpdates = () => {
-  if (process.platform !== 'win32') {
+  if (
+    process.platform !== 'win32' &&
+    process.platform !== 'linux'
+  ) {
     return () => {}
   }
 
@@ -383,9 +386,12 @@ const checkForUpdates = () => {
   }
 }
 
-// TODO: don't support auto-update for linux and mac right now
+// TODO: don't support auto-update for mac right now
 const checkForUpdatesAndNotify = (opts) => {
-  if (process.platform !== 'win32') {
+  if (
+    process.platform !== 'win32' &&
+    process.platform !== 'linux'
+  ) {
     return
   }
 
@@ -402,9 +408,12 @@ const checkForUpdatesAndNotify = (opts) => {
     .checkForUpdatesAndNotify()
 }
 
-// TODO: don't support update for linux and mac right now
+// TODO: don't support update for mac right now
 const quitAndInstall = () => {
-  if (process.platform !== 'win32') {
+  if (
+    process.platform !== 'win32' &&
+    process.platform !== 'linux'
+  ) {
     return () => {}
   }
 

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -4,7 +4,6 @@ const { ipcMain, Menu } = require('electron')
 const fs = require('fs')
 const path = require('path')
 const {
-  AppImageUpdater,
   MacUpdater,
   NsisUpdater,
   AppUpdater
@@ -12,6 +11,7 @@ const {
 const log = require('electron-log')
 const Alert = require('electron-alert')
 
+const BfxAppImageUpdater = require('./bfx.appimage.updater')
 const wins = require('../windows')
 
 const toastStyle = fs.readFileSync(path.join(
@@ -215,7 +215,7 @@ const _autoUpdaterFactory = () => {
     autoUpdater = new MacUpdater()
   }
   if (process.platform === 'linux') {
-    autoUpdater = new AppImageUpdater()
+    autoUpdater = new BfxAppImageUpdater()
   }
 
   autoUpdater.on('error', () => {

--- a/src/auto-updater/utils.js
+++ b/src/auto-updater/utils.js
@@ -1,0 +1,68 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const log = require('electron-log')
+
+const appDir = path.dirname(require.main.filename)
+const _root = path.join(appDir, '../..')
+const {
+  version
+} = require(path.join(appDir, 'package.json'))
+
+const isZipRelease = (root = _root) => {
+  const isZipReleaseFile = path.join(root, 'isZipRelease')
+
+  return fs.existsSync(isZipReleaseFile)
+}
+
+const getTempReleaseFilePath = (root = _root) => {
+  const fileName = `BitfinexReport-${version}-x64-linux.AppImage`
+  const filePath = path.join(root, '..', fileName)
+
+  return filePath
+}
+
+const setAppImagePath = (
+  appImagePath = getTempReleaseFilePath()
+) => {
+  process.env.APPIMAGE = appImagePath
+}
+
+const setAppImagePathIfZipRelease = () => {
+  if (!isZipRelease()) return
+
+  setAppImagePath()
+}
+
+if (isZipRelease()) {
+  setAppImagePath()
+}
+
+const makeTempReleaseFile = (filePath) => {
+  fs.writeFileSync(filePath, '')
+}
+
+const prepareInstall = () => {
+  const root = path.join(appDir, '../..')
+
+  if (!isZipRelease(root)) {
+    return
+  }
+
+  try {
+    fs.rmdirSync(root, { recursive: true })
+  } catch (err) {
+    log.error(err)
+  }
+
+  const filePath = getTempReleaseFilePath(root)
+  makeTempReleaseFile(filePath)
+  setAppImagePath(filePath)
+}
+
+module.exports = {
+  isZipRelease,
+  prepareInstall,
+  setAppImagePathIfZipRelease
+}

--- a/src/auto-updater/utils.js
+++ b/src/auto-updater/utils.js
@@ -35,12 +35,24 @@ const setAppImagePathIfZipRelease = () => {
   setAppImagePath()
 }
 
-if (isZipRelease()) {
-  setAppImagePath()
+const makeTempReleaseFile = (filePath) => {
+  try {
+    fs.writeFileSync(filePath, '')
+  } catch (err) {
+    log.error(err)
+  }
 }
 
-const makeTempReleaseFile = (filePath) => {
-  fs.writeFileSync(filePath, '')
+const rmOldReleaseDir = (root) => {
+  if (!root) {
+    return
+  }
+
+  try {
+    fs.rmdirSync(root, { recursive: true })
+  } catch (err) {
+    log.error(err)
+  }
 }
 
 const prepareInstall = () => {
@@ -50,19 +62,16 @@ const prepareInstall = () => {
     return
   }
 
-  try {
-    fs.rmdirSync(root, { recursive: true })
-  } catch (err) {
-    log.error(err)
-  }
-
   const filePath = getTempReleaseFilePath(root)
   makeTempReleaseFile(filePath)
   setAppImagePath(filePath)
+
+  return root
 }
 
 module.exports = {
   isZipRelease,
   prepareInstall,
+  rmOldReleaseDir,
   setAppImagePathIfZipRelease
 }

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -21,8 +21,11 @@ module.exports = ({
   pathToUserData,
   pathToUserDocuments
 }) => {
-  // TODO: don't support update for linux and mac right now
-  const autoUpdateMenuItem = process.platform === 'win32'
+  // TODO: don't support update for mac right now
+  const autoUpdateMenuItem = (
+    process.platform === 'win32' ||
+    process.platform === 'linux'
+  )
     ? [
       { type: 'separator' },
       {

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -35,6 +35,9 @@ const {
 const {
   checkForUpdatesAndNotify
 } = require('./auto-updater')
+const {
+  isZipRelease
+} = require('./auto-updater/utils')
 
 const pathToLayouts = path.join(__dirname, 'layouts')
 const pathToLayoutAppInitErr = path
@@ -76,12 +79,20 @@ module.exports = () => {
         const pathToUserData = app.getPath('userData')
         const pathToUserDocuments = app.getPath('documents')
 
+        const pathToUserCsv = (
+          process.platform === 'darwin' ||
+          (
+            process.platform === 'linux' &&
+            !isZipRelease()
+          )
+        )
+          ? pathToUserDocuments
+          : '../../..'
+
         configsKeeperFactory(
           { pathToUserData },
           {
-            pathToUserCsv: process.platform === 'darwin'
-              ? pathToUserDocuments
-              : '../../..',
+            pathToUserCsv,
             schedulerRule
           }
         )


### PR DESCRIPTION
This PR adds the auto-update for Linux, it's the next part of the previous auto-update PR https://github.com/bitfinexcom/bfx-report-electron/pull/82
Basic changes:
  - Adds ability to build [AppImage](https://www.electron.build/configuration/appimage) releases
  - Adds supporting auto-update for Linux
  - Fixes Linux launcher to avoid redundant warning
  - Adds the ability to perform auto-update for Linux `ZIP` release
  - Fixes missing `bc` cli in docker container
  - Fixes `csv` export issue for `AppImage`, forces storing in `~/Documents` dir
  - Bumps electron version up to `11.4.2` to fix a crash when exiting app with active nodejs `worker_threads` https://github.com/electron/electron/pull/28471
  - Avoids redundant logs

TODO:
  - auto-update feature for Mac