### PR TITLE
Change users export csv folder path

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -189,6 +189,11 @@ fi
 
 cd $unpackedFolder
 
+if [ $targetPlatform == "win" ]
+then
+  touch "$isZipReleaseFile"
+fi
+
 if [ $targetPlatform == "linux" ]
 then
   # Build C executable launcher file

--- a/server.js
+++ b/server.js
@@ -53,10 +53,6 @@ let isMigrationsError = false
       throw new WrongPathToUserCsvError()
     }
 
-    const isRelativePath = pathToUserCsv.startsWith('..')
-    const pathToCsvFolder = isRelativePath
-      ? path.join(pathToUserCsv, 'csv')
-      : path.join(pathToUserCsv, 'BitfinexReports')
     const defaultPorts = getDefaultPorts()
     const {
       grape1DhtPort,
@@ -116,7 +112,7 @@ let isMigrationsError = false
       '--isSchedulerEnabled=true',
       '--isElectronjsEnv=true',
       '--isLoggerDisabled=false',
-      `--csvFolder=${pathToCsvFolder}`,
+      `--csvFolder=${pathToUserCsv}`,
       `--tempFolder=${pathToUserData}/temp`,
       `--logsFolder=${pathToUserData}/logs`,
       `--dbFolder=${pathToUserData}`,

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -420,29 +420,41 @@ const _autoUpdaterFactory = () => {
 }
 
 const checkForUpdates = () => {
-  return () => {
-    isIntervalUpdate = false
+  return async () => {
+    try {
+      isIntervalUpdate = false
+      _switchMenuItem({
+        isCheckMenuItemDisabled: true
+      })
+
+      const res = await _autoUpdaterFactory()
+        .checkForUpdates()
+
+      return res
+    } catch (err) {
+      console.error(err)
+    }
+  }
+}
+
+const checkForUpdatesAndNotify = async (opts) => {
+  try {
+    const {
+      isIntervalUpdate: isIntUp = false
+    } = { ...opts }
+
+    isIntervalUpdate = isIntUp
     _switchMenuItem({
       isCheckMenuItemDisabled: true
     })
 
-    return _autoUpdaterFactory()
-      .checkForUpdates()
+    const res = await _autoUpdaterFactory()
+      .checkForUpdatesAndNotify()
+
+    return res
+  } catch (err) {
+    console.error(err)
   }
-}
-
-const checkForUpdatesAndNotify = (opts) => {
-  const {
-    isIntervalUpdate: isIntUp = false
-  } = { ...opts }
-
-  isIntervalUpdate = isIntUp
-  _switchMenuItem({
-    isCheckMenuItemDisabled: true
-  })
-
-  return _autoUpdaterFactory()
-    .checkForUpdatesAndNotify()
 }
 
 const quitAndInstall = () => {

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -19,6 +19,7 @@ const {
 } = require('./change-loading-win-visibility-state')
 const {
   showWindow,
+  hideWindow,
   centerWindow
 } = require('./helpers/manage-window')
 
@@ -231,6 +232,7 @@ const createErrorWindow = async (pathname) => {
   )
 
   await hideLoadingWindow()
+  await hideWindow(wins.mainWindow)
 
   return winProps
 }


### PR DESCRIPTION
This PR adds the ability to export csv files by default in the following ways:
  - if user uses Mac or AppImage on Linux or NSIS on Windows csv files would be stored in `app.getPath('documents')` + `bitfinex/reports` folder https://www.electronjs.org/docs/api/app#appgetpathname
  - if user uses Zip releases (not Mac) csv files would be stored in `csv` folder of the application root

However, the export path can still be specified via the menu item option

Basic changes:
  - Changes users export csv folder path
  - Don't crash the app when checking for updates is failed
  - Hide the main window when the app can't be initialized
  
  **Depends** on this PR:
  - https://github.com/bitfinexcom/bfx-report-electron/pull/85