### PR TITLE
Fix supporting node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "electron-log": "^4.3.2",
     "electron-root-path": "^1.0.16",
     "electron-serve": "^1.0.0",
-    "electron-updater": "^4.3.8",
+    "electron-updater": "4.3.8",
     "extract-zip": "^2.0.1",
     "find-free-port": "^2.0.0",
     "github-markdown-css": "^4.0.0",


### PR DESCRIPTION
This PR fixes supporting node v12.*. The issue is following: the `electron-updater` was updated with adding this

https://github.com/electron-userland/electron-builder/commit/c623279a31d3d203ad1f150d83905a7e1f58a731#diff-9da93fcc7c4be00ef66a6210b155ac689b7f761ec0bfc6a97346e1dfd1d77386R5

```js
import { mkdir, readFile, rename, unlink } from "fs/promises"
```

The error was due to unsupported Node version 12.x which doesn't support this require statement
https://stackoverflow.com/questions/64725249/fs-promises-api-in-typescript-not-compiling-in-javascript-correctly

**Note**: when we take this PR https://github.com/bitfinexcom/bfx-report-electron/pull/90 the hardcode of `electron-updater` might be removed due nodejs would be bumped up