### PR TITLE
Fix electron-alert modal dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "clean-stack": "^3.0.1",
     "cron-validate": "^1.4.2",
     "ed25519-supercop": "^2.0.1",
-    "electron-alert": "^0.1.11",
+    "electron-alert": "0.1.13",
     "electron-log": "^4.3.2",
     "electron-root-path": "^1.0.16",
     "electron-serve": "^1.0.0",


### PR DESCRIPTION
This PR fixes the [electron-alert](https://github.com/rocketlaunchr/electron-alert) modal dialog. The new `0.1.14` version has been updated to Swal v11 https://github.com/rocketlaunchr/electron-alert/pull/12 and it breaks the codebase. As a solution, need to hardcode `0.1.13`. In the future would add support for `0.1.14` version