### PR TITLE
Add improvements for dev mode

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,7 @@ services:
       dockerfile: Dockerfile.ui-builder
     environment:
       BRANCH: ${BRANCH}
+      UI_BUILD_FOLDER: /ui-build
     volumes:
       - ui-build:/ui-build
 
@@ -20,6 +21,7 @@ services:
       ELECTRON_CACHE: /root/.cache/electron
       ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
       BRANCH: ${BRANCH}
+      UI_BUILD_FOLDER: /ui-build
     volumes:
       - ui-build:/ui-build
       - ./dist:/dist
@@ -35,6 +37,7 @@ services:
       ELECTRON_CACHE: /root/.cache/electron
       ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
       BRANCH: ${BRANCH}
+      UI_BUILD_FOLDER: /ui-build
     volumes:
       - ui-build:/ui-build
       - ./dist:/dist
@@ -50,6 +53,7 @@ services:
       ELECTRON_CACHE: /root/.cache/electron
       ELECTRON_BUILDER_CACHE: /root/.cache/electron-builder
       BRANCH: ${BRANCH}
+      UI_BUILD_FOLDER: /ui-build
     volumes:
       - ui-build:/ui-build
       - ./dist:/dist

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "app-builder-bin": "^3.5.13",
-    "electron": "13.1.2",
+    "electron": "13.1.6",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "extract-zip": "^2.0.1",
     "find-free-port": "^2.0.0",
     "github-markdown-css": "^4.0.0",
-    "grenache-grape": "^0.9.8",
+    "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.15",
     "new-github-issue-url": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",
-    "standard": "^14.3.1"
+    "standard": "^16.0.3"
   },
   "standard": {
     "globals": [

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -3,6 +3,7 @@
 set -x
 
 export CI_ENVIRONMENT_NAME=production
+export SKIP_PREFLIGHT_CHECK=true
 
 ROOT="$PWD"
 frontendFolder="$ROOT/bfx-report-ui"

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -10,7 +10,6 @@ frontendFolder="$ROOT/bfx-report-ui"
 pathToTriggerElectronLoad="$frontendFolder/src/utils/triggerElectronLoad.js"
 pathToFonts="$frontendFolder/src/styles/fonts"
 uiBuildFolder="$frontendFolder/build"
-uiReadyFile="$uiBuildFolder/READY"
 branch=master
 
 source $ROOT/scripts/update-submodules.sh
@@ -29,6 +28,7 @@ then
 fi
 
 mkdir $uiBuildFolder 2>/dev/null
+uiReadyFile="$uiBuildFolder/READY"
 rm -rf $uiBuildFolder/*
 
 function usage {

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -95,10 +95,10 @@ sed -i -e \
   "s/showFrameworkMode: false/showFrameworkMode: true/g" \
   $frontendFolder/src/config.js
 
-rm -f "$ROOT/.eslintrc"
-
+mv -f "$ROOT/.eslintrc" "$ROOT/eslint-conf-disabled-for-ui"
 npm i --no-audit
 npm run build
+mv -f "$ROOT/eslint-conf-disabled-for-ui" "$ROOT/.eslintrc"
 
 if ! [ -s "$frontendFolder/build/index.html" ]; then
   exit 1

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -9,7 +9,7 @@ ROOT="$PWD"
 frontendFolder="$ROOT/bfx-report-ui"
 pathToTriggerElectronLoad="$frontendFolder/src/utils/triggerElectronLoad.js"
 pathToFonts="$frontendFolder/src/styles/fonts"
-uiBuildFolder=/ui-build
+uiBuildFolder="$frontendFolder/build"
 uiReadyFile="$uiBuildFolder/READY"
 branch=master
 
@@ -23,7 +23,12 @@ if [ "$BRANCH" != "" ]
 then
   branch=$BRANCH
 fi
+if [ "$UI_BUILD_FOLDER" != "" ]
+then
+  uiBuildFolder=$UI_BUILD_FOLDER
+fi
 
+mkdir $uiBuildFolder 2>/dev/null
 rm -rf $uiBuildFolder/*
 
 function usage {

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -62,7 +62,13 @@ expressFolder="$frontendFolder/bfx-report-express"
 backendFolder="$ROOT/bfx-reports-framework"
 
 linuxLauncherFolder="$ROOT/build/linux-launcher"
-uiBuildFolder=/ui-build
+
+uiBuildFolder="$frontendFolder/build"
+if [ "$UI_BUILD_FOLDER" != "" ]
+then
+  uiBuildFolder=$UI_BUILD_FOLDER
+fi
+mkdir $uiBuildFolder 2>/dev/null
 uiReadyFile="$uiBuildFolder/READY"
 
 mkdir $ROOT/dist 2>/dev/null

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -7,6 +7,7 @@ branch=master
 dbDriver=better-sqlite
 lastCommitFileName=lastCommit.json
 isZipReleaseFile="isZipRelease"
+bfxStagingUrl="https://api.staging.bitfinex.com"
 
 source $ROOT/scripts/get-conf-value.sh
 source $ROOT/scripts/escape-string.sh
@@ -110,8 +111,9 @@ sed -i -e \
   $backendFolder/config/service.report.json
 
 if [ $isDevEnv != 0 ]; then
+  escapedBfxStagingUrl=$(escapeString $bfxStagingUrl)
   sed -i -e \
-    "s/\"restUrl\": \".*\"/\"restUrl\": \"https:\/\/test.bitfinex.com\"/g" \
+    "s/\"restUrl\": \".*\"/\"restUrl\": \"$escapedBfxStagingUrl\"/g" \
     $backendFolder/config/service.report.json
 fi
 

--- a/src/change-sync-frequency.js
+++ b/src/change-sync-frequency.js
@@ -176,7 +176,8 @@ module.exports = () => {
         ...alertOptions,
         text,
         inputValue: timeFormat.value === timeData.timeFormat
-          ? timeData.value : 1,
+          ? timeData.value
+          : 1,
         inputAttributes: {
           min: 1,
           max: 31,
@@ -189,7 +190,8 @@ module.exports = () => {
         ...alertOptions,
         text,
         inputValue: timeFormat.value === timeData.timeFormat
-          ? timeData.value : 2,
+          ? timeData.value
+          : 2,
         inputAttributes: {
           min: 1,
           max: 23,
@@ -202,7 +204,8 @@ module.exports = () => {
       ...alertOptions,
       text,
       inputValue: timeFormat.value === timeData.timeFormat
-        ? timeData.value : 20,
+        ? timeData.value
+        : 20,
       inputAttributes: {
         min: 10,
         max: 59,

--- a/src/error-manager/render-markdown-template.js
+++ b/src/error-manager/render-markdown-template.js
@@ -10,7 +10,7 @@ const templateByDefault = fs.readFileSync(
   path.join(__dirname, 'github-issue-template.md'),
   'utf8'
 )
-const placeholderPattern = new RegExp(/\$\{[a-zA-Z0-9]+\}/, 'g')
+const placeholderPattern = /\$\{[a-zA-Z0-9]+\}/g
 
 // The GitHub GET endpoint for opening a new issue
 // has a restriction for maximum length of a URL: 8192 bytes

--- a/src/helpers/get-debug-info.js
+++ b/src/helpers/get-debug-info.js
@@ -9,11 +9,18 @@ const productName = 'Bitfinex Report'
 
 const { getAppUpdateConfigSync } = require('../auto-updater')
 
-const appUpdateConfig = getAppUpdateConfigSync()
 const packageJson = require(path.join(appDir, 'package.json'))
 
 let lastCommit = { hash: '-', date: '-' }
+let appUpdateConfig = {}
 
+try {
+  appUpdateConfig = getAppUpdateConfigSync()
+} catch (err) {
+  console.debug(err)
+
+  appUpdateConfig = packageJson.build.publish
+}
 try {
   lastCommit = require(path.join(appDir, 'lastCommit.json'))
 } catch (err) {

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -56,9 +56,9 @@ const _createWindow = async (
     manage
   } = isMainWindow
     ? windowStateKeeper({
-      defaultWidth,
-      defaultHeight
-    })
+        defaultWidth,
+        defaultHeight
+      })
     : {}
   const _props = {
     autoHideMenuBar: true,
@@ -82,10 +82,10 @@ const _createWindow = async (
 
   const startUrl = pathname
     ? url.format({
-      pathname,
-      protocol: 'file:',
-      slashes: true
-    })
+        pathname,
+        protocol: 'file:',
+        slashes: true
+      })
     : 'app://-'
 
   if (!pathname) {


### PR DESCRIPTION
This PR adds improvements for dev mode to be able to launch electron without building releases using:

```console
npm run init
or npm run init -d

npm run electron
```

Basic changes:
  - Fixes app update config for dev mode
  - Fixes ui build for dev mode
  - Fixes setting bfx staging url for dev mode
  - Fixes eslint config for dev mode
  - Adds ability to get `grenache-grape` from github url
  - Disables react preflight check when ui is building
  - Bumped standard up to 16.*, fixes corresponding code style
  - Bumped electron up to `13.1.6` which has important fixes. There are fixed the found issue https://github.com/electron/electron/issues/29732, check https://github.com/electron/electron/pull/29813 and https://github.com/electron/electron/pull/29956