### PR TITLE
Clear all tables

### DIFF
--- a/build/linux-launcher/launcher.sh
+++ b/build/linux-launcher/launcher.sh
@@ -10,7 +10,7 @@ appFilePath="$ROOT/app"
 logFilePath="$ROOT/error.log"
 
 output=$("$appFilePath" 2>&1)
-mess=$(echo "$output" | grep -v WARNING | grep -v electron\/issues\/23506 | grep -v Cannot\ download\ differentially)
+mess=$(echo "$output" | grep -v WARNING | grep -v electron\/issues\/23506 | grep -v Cannot\ download\ differentially | grep -v GtkDialog mapped without a transient parent)
 
 if [ "$mess" != "" ]; then
   echo $mess>>"$logFilePath"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "app-builder-bin": "^3.5.13",
-    "electron": "13.1.6",
+    "electron": "13.1.7",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
       "repo": "bfx-report-electron",
       "owner": "bitfinexcom",
       "channel": "latest",
+      "allowPrerelease": true,
       "useMultipleRangeRequest": false,
       "updaterCacheDirName": "bfx-report-electron-updater"
     },

--- a/server.js
+++ b/server.js
@@ -155,7 +155,7 @@ let isMigrationsError = false
     const ipcReadyPromise = new Promise((resolve, reject) => {
       ipc.once('error', reject)
 
-      const handler = (mess) => {
+      const handlerMess = (mess) => {
         const { state } = { ...mess }
 
         if (state === 'error:migrations') {
@@ -168,13 +168,19 @@ let isMigrationsError = false
           return
         }
 
-        ipc.removeListener('error', reject)
-        ipc.removeListener('message', handler)
+        ipc.removeListener('error', handlerErr)
+        ipc.removeListener('message', handlerMess)
 
         resolve()
       }
-
-      ipc.on('message', handler)
+      const handlerErr = (err) => {
+        ipc.removeListener('message', handlerMess)
+  
+        reject(err)
+      }
+  
+      ipc.once('error', handlerErr)
+      ipc.on('message', handlerMess)
     })
 
     await Promise.all([announcePromise, ipcReadyPromise])

--- a/server.js
+++ b/server.js
@@ -135,7 +135,10 @@ let isMigrationsError = false
     ipc.on('message', (mess) => {
       const { state } = { ...mess }
 
-      if (state !== 'all-tables-have-been-cleared') {
+      if (
+        state !== 'all-tables-have-been-cleared' ||
+        state !== 'all-tables-have-not-been-cleared'
+      ) {
         return
       }
 

--- a/server.js
+++ b/server.js
@@ -132,6 +132,25 @@ let isMigrationsError = false
       })
     })
 
+    ipc.on('message', (mess) => {
+      const { state } = { ...mess }
+
+      if (state !== 'all-tables-have-been-cleared') {
+        return
+      }
+
+      process.send(mess)
+    })
+    process.on('message', (mess) => {
+      const { state } = { ...mess }
+
+      if (state !== 'clear-all-tables') {
+        return
+      }
+
+      ipc.send(mess)
+    })
+
     const announcePromise = grapes.onAnnounce('rest:report:api')
     const ipcReadyPromise = new Promise((resolve, reject) => {
       ipc.once('error', reject)

--- a/server.js
+++ b/server.js
@@ -136,7 +136,7 @@ let isMigrationsError = false
       const { state } = { ...mess }
 
       if (
-        state !== 'all-tables-have-been-cleared' ||
+        state !== 'all-tables-have-been-cleared' &&
         state !== 'all-tables-have-not-been-cleared'
       ) {
         return

--- a/src/const.js
+++ b/src/const.js
@@ -3,11 +3,15 @@
 const CONFIGS_FILE_NAME = 'bfx-report-configs.json'
 const DEFAULT_ARCHIVE_DB_FILE_NAME = 'bfx-report-db-archive'
 const DB_FILE_NAME = 'db-sqlite_sync_m0.db'
+const DB_SHM_FILE_NAME = `${DB_FILE_NAME}-shm`
+const DB_WAL_FILE_NAME = `${DB_FILE_NAME}-wal`
 const SECRET_KEY_FILE_NAME = 'secret-key'
 
 module.exports = {
   CONFIGS_FILE_NAME,
   DEFAULT_ARCHIVE_DB_FILE_NAME,
   DB_FILE_NAME,
+  DB_SHM_FILE_NAME,
+  DB_WAL_FILE_NAME,
   SECRET_KEY_FILE_NAME
 }

--- a/src/create-menu.js
+++ b/src/create-menu.js
@@ -84,6 +84,14 @@ module.exports = ({
           click: removeDB({ pathToUserData })
         },
         {
+          label: 'Clear all data',
+          accelerator: 'CmdOrCtrl+D',
+          click: removeDB({
+            pathToUserData,
+            shouldAllTablesBeCleared: true
+          })
+        },
+        {
           label: 'Change reports folder',
           accelerator: 'CmdOrCtrl+F',
           click: changeReportsFolder({ pathToUserDocuments })

--- a/src/export-db.js
+++ b/src/export-db.js
@@ -14,6 +14,8 @@ const {
 const {
   DEFAULT_ARCHIVE_DB_FILE_NAME,
   DB_FILE_NAME,
+  DB_SHM_FILE_NAME,
+  DB_WAL_FILE_NAME,
   SECRET_KEY_FILE_NAME
 } = require('./const')
 
@@ -30,6 +32,8 @@ module.exports = ({
     `${DEFAULT_ARCHIVE_DB_FILE_NAME}-${timestamp}.zip`
   )
   const dbPath = path.join(pathToUserData, DB_FILE_NAME)
+  const dbShmPath = path.join(pathToUserData, DB_SHM_FILE_NAME)
+  const dbWalPath = path.join(pathToUserData, DB_WAL_FILE_NAME)
   const secretKeyPath = path.join(pathToUserData, SECRET_KEY_FILE_NAME)
 
   return async () => {
@@ -60,7 +64,12 @@ module.exports = ({
       }
 
       await showLoadingWindow()
-      await zip(filePath, [dbPath, secretKeyPath])
+      await zip(filePath, [
+        dbPath,
+        dbShmPath,
+        dbWalPath,
+        secretKeyPath
+      ])
       await hideLoadingWindow()
 
       await showMessageModalDialog(win, {

--- a/src/import-db.js
+++ b/src/import-db.js
@@ -13,6 +13,8 @@ const relaunch = require('./relaunch')
 const { rm } = require('./helpers')
 const {
   DB_FILE_NAME,
+  DB_SHM_FILE_NAME,
+  DB_WAL_FILE_NAME,
   SECRET_KEY_FILE_NAME
 } = require('./const')
 
@@ -78,7 +80,14 @@ module.exports = ({
       const extractedfileNames = await unzip(
         filePaths[0],
         pathToUserData,
-        { extractFiles: [DB_FILE_NAME, SECRET_KEY_FILE_NAME] }
+        {
+          extractFiles: [
+            DB_FILE_NAME,
+            DB_SHM_FILE_NAME,
+            DB_WAL_FILE_NAME,
+            SECRET_KEY_FILE_NAME
+          ]
+        }
       )
 
       if (extractedfileNames.every(file => file !== DB_FILE_NAME)) {

--- a/src/pause-app.js
+++ b/src/pause-app.js
@@ -28,9 +28,11 @@ const _closeServer = () => {
   })
 }
 
-module.exports = async ({
-  beforeClosingServHook = () => {}
-}) => {
+module.exports = async (opts = {}) => {
+  const {
+    beforeClosingServHook = () => {}
+  } = opts
+
   await showLoadingWindow({ isRequiredToCloseAllWins: true })
 
   await beforeClosingServHook()

--- a/src/pause-app.js
+++ b/src/pause-app.js
@@ -28,8 +28,12 @@ const _closeServer = () => {
   })
 }
 
-module.exports = async () => {
+module.exports = async ({
+  beforeClosingServHook = () => {}
+}) => {
   await showLoadingWindow({ isRequiredToCloseAllWins: true })
+
+  await beforeClosingServHook()
 
   await _closeServer()
 }

--- a/src/relaunch.js
+++ b/src/relaunch.js
@@ -2,6 +2,10 @@
 
 const electron = require('electron')
 
+const {
+  isZipRelease
+} = require('./auto-updater/utils')
+
 module.exports = () => {
   const app = electron.app || electron.remote.app
 
@@ -9,7 +13,10 @@ module.exports = () => {
     args: process.argv.slice(1).concat(['--relaunch'])
   }
 
-  if (process.env.APPIMAGE) {
+  if (
+    process.env.APPIMAGE &&
+    !isZipRelease()
+  ) {
     options.execPath = process.env.APPIMAGE
     options.args.unshift('--appimage-extract-and-run')
   }

--- a/src/relaunch.js
+++ b/src/relaunch.js
@@ -5,6 +5,15 @@ const electron = require('electron')
 module.exports = () => {
   const app = electron.app || electron.remote.app
 
-  app.relaunch({ args: process.argv.slice(1).concat(['--relaunch']) })
+  const options = {
+    args: process.argv.slice(1).concat(['--relaunch'])
+  }
+
+  if (process.env.APPIMAGE) {
+    options.execPath = process.env.APPIMAGE
+    options.args.unshift('--appimage-extract-and-run')
+  }
+
+  app.relaunch(options)
   app.exit(0)
 }

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -92,14 +92,20 @@ module.exports = ({
 }) => {
   return async () => {
     const win = electron.BrowserWindow.getFocusedWindow()
+    const title = shouldAllTablesBeCleared
+      ? 'Clear all data'
+      : 'Remove database'
+    const message = shouldAllTablesBeCleared
+      ? 'Are you sure you want to clear all data?'
+      : 'Are you sure you want to remove the database?'
 
     try {
       const {
         btnId
       } = await showMessageModalDialog(win, {
         type: 'question',
-        title: 'Remove database',
-        message: 'Are you sure you want to remove the database?'
+        title,
+        message
       })
       const isOkBtnPushed = btnId === 1
 
@@ -115,7 +121,7 @@ module.exports = ({
       relaunch()
     } catch (err) {
       try {
-        await showErrorModalDialog(win, 'Remove database', err)
+        await showErrorModalDialog(win, title, err)
       } catch (err) {
         console.error(err)
       }

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -48,8 +48,8 @@ const _clearAllTables = () => {
         return
       }
 
-      ipc.removeListener('error', reject)
-      ipc.removeListener('message', handler)
+      ipc.removeListener('error', handlerErr)
+      ipc.removeListener('message', handlerMess)
 
       resolve()
     }

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -44,12 +44,21 @@ const _clearAllTables = () => {
     const handlerMess = (mess) => {
       const { state } = { ...mess }
 
-      if (state !== 'all-tables-have-been-cleared') {
+      if (
+        state !== 'all-tables-have-been-cleared' ||
+        state !== 'all-tables-have-not-been-cleared'
+      ) {
         return
       }
 
       ipc.removeListener('error', handlerErr)
       ipc.removeListener('message', handlerMess)
+
+      if (state === 'all-tables-have-not-been-cleared') {
+        reject(new DbRemovingError(state))
+
+        return
+      }
 
       resolve()
     }


### PR DESCRIPTION
This PR adds the ability to clear all tables. Basic changes:
  - Adds the option `Clear all data` to the main menu bar
  - Bumps electron version up to `13.1.7`
  - Allows prereleases to be able to work with auto-update with semantic beta versions like `vX.X.X-beta.X`
  - Fixes ability to relaunch app for Linux releases (it uses when auto-update/import/remove-db/clear-all-data) https://github.com/electron-userland/electron-builder/issues/1727#issuecomment-769896927
  - Don't show `GtkDialog` warning, related to the electron issue https://github.com/electron/electron/issues/12423
  - Fixes `import/export` DB feature - there has to add sqlite WAL file to import/export `.zip`
  
  **Depends** on this PR:
    - https://github.com/bitfinexcom/bfx-reports-framework/pull/179