### PR TITLE
Bump electron version up to 13.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "app-builder-bin": "^3.5.13",
-    "electron": "13.1.9",
+    "electron": "13.4.0",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",


### PR DESCRIPTION
This PR bumps electron version up to `13.4.0` to have the following fixes:
  - https://github.com/electron/electron/releases/tag/v13.2.0
  - https://github.com/electron/electron/releases/tag/v13.2.1
  - https://github.com/electron/electron/releases/tag/v13.2.2
  - https://github.com/electron/electron/releases/tag/v13.2.3
  - https://github.com/electron/electron/releases/tag/v13.3.0
  - https://github.com/electron/electron/releases/tag/v13.4.0