### PR TITLE
Bump electron version up to 13.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "app-builder-bin": "^3.5.13",
-    "electron": "13.4.0",
+    "electron": "13.5.1",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "node-pre-gyp": "^0.11.0",


### PR DESCRIPTION
This PR bumps the electron version up to 13.5.1 to have the following fixes:
  - https://github.com/electron/electron/releases/tag/v13.5.0
  - https://github.com/electron/electron/releases/tag/v13.5.1