### PR TITLE
Hardcode/update package versions

### DIFF
--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -4,9 +4,10 @@ ENV NODE_VERSION 14.16.0
 
 COPY ./scripts/install-nodejs.sh ./scripts/install-nodejs.sh
 
-RUN  ./scripts/install-nodejs.sh $NODE_VERSION \
-  && wget -nv https://download.opensuse.org/repositories/Emulators:/Wine:/Debian/xUbuntu_18.04/Release.key -O Release.key \
-  && apt-key add - < Release.key \
+RUN ./scripts/install-nodejs.sh $NODE_VERSION \
+  # Remove the `Wine` source entry to resolve
+  # the release key expiration issue for `apt-get update`
+  && sed -i '/Wine/d' /etc/apt/sources.list \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
     p7zip-full \

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "cron-validate": "1.4.3",
     "ed25519-supercop": "2.0.1",
     "electron-alert": "0.1.13",
-    "electron-log": "^4.3.2",
+    "electron-log": "4.4.1",
     "electron-root-path": "^1.0.16",
     "electron-serve": "^1.0.0",
     "electron-updater": "4.3.8",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "electron-updater": "4.3.8",
     "extract-zip": "2.0.1",
     "find-free-port": "2.0.0",
-    "github-markdown-css": "^4.0.0",
+    "github-markdown-css": "4.0.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "^4.0.0",
     "lodash": "^4.17.15",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lodash": "4.17.21",
     "new-github-issue-url": "0.2.1",
     "showdown": "1.9.1",
-    "truncate-utf8-bytes": "^1.0.2",
+    "truncate-utf8-bytes": "1.0.2",
     "yauzl": "^2.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "find-free-port": "2.0.0",
     "github-markdown-css": "4.0.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
-    "js-yaml": "^4.0.0",
+    "js-yaml": "4.1.0",
     "lodash": "^4.17.15",
     "new-github-issue-url": "^0.2.1",
     "showdown": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "electron-serve": "1.1.0",
     "electron-updater": "4.3.8",
     "extract-zip": "2.0.1",
-    "find-free-port": "^2.0.0",
+    "find-free-port": "2.0.0",
     "github-markdown-css": "^4.0.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "@mapbox/node-pre-gyp": "1.0.6",
-    "standard": "^16.0.3"
+    "standard": "16.0.4"
   },
   "standard": {
     "globals": [

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "electron": "13.4.0",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
-    "node-pre-gyp": "^0.11.0",
+    "@mapbox/node-pre-gyp": "1.0.6",
     "standard": "^16.0.3"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "async": "3.2.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "10.0.2",
-    "clean-stack": "^3.0.1",
+    "clean-stack": "3.0.1",
     "cron-validate": "^1.4.2",
     "ed25519-supercop": "^2.0.1",
     "electron-alert": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "archiver": "5.3.0",
-    "async": "3.2.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "10.0.2",
     "clean-stack": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "new-github-issue-url": "0.2.1",
     "showdown": "1.9.1",
     "truncate-utf8-bytes": "1.0.2",
-    "yauzl": "^2.10.0"
+    "yauzl": "2.10.0"
   },
   "devDependencies": {
     "app-builder-bin": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "electron-alert": "0.1.13",
     "electron-log": "4.4.1",
     "electron-root-path": "1.0.16",
-    "electron-serve": "^1.0.0",
+    "electron-serve": "1.1.0",
     "electron-updater": "4.3.8",
     "extract-zip": "^2.0.1",
     "find-free-port": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "archiver": "5.3.0",
     "async": "3.2.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
-    "bittorrent-dht": "^8.4.0",
+    "bittorrent-dht": "10.0.2",
     "clean-stack": "^3.0.1",
     "cron-validate": "^1.4.2",
     "ed25519-supercop": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "dependencies": {
-    "archiver": "^3.1.1",
+    "archiver": "5.3.0",
     "async": "^2.6.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "^8.4.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",
     "new-github-issue-url": "0.2.1",
-    "showdown": "^1.9.1",
+    "showdown": "1.9.1",
     "truncate-utf8-bytes": "^1.0.2",
     "yauzl": "^2.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "github-markdown-css": "4.0.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "4.1.0",
-    "lodash": "^4.17.15",
+    "lodash": "4.17.21",
     "new-github-issue-url": "^0.2.1",
     "showdown": "^1.9.1",
     "truncate-utf8-bytes": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "4.1.0",
     "lodash": "4.17.21",
-    "new-github-issue-url": "^0.2.1",
+    "new-github-issue-url": "0.2.1",
     "showdown": "^1.9.1",
     "truncate-utf8-bytes": "^1.0.2",
     "yauzl": "^2.10.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "app-builder-bin": "4.1.0",
-    "electron": "13.4.0",
+    "electron": "13.6.1",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",
     "@mapbox/node-pre-gyp": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "bittorrent-dht": "10.0.2",
     "clean-stack": "3.0.1",
     "cron-validate": "1.4.3",
-    "ed25519-supercop": "^2.0.1",
+    "ed25519-supercop": "2.0.1",
     "electron-alert": "0.1.13",
     "electron-log": "^4.3.2",
     "electron-root-path": "^1.0.16",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ed25519-supercop": "2.0.1",
     "electron-alert": "0.1.13",
     "electron-log": "4.4.1",
-    "electron-root-path": "^1.0.16",
+    "electron-root-path": "1.0.16",
     "electron-serve": "^1.0.0",
     "electron-updater": "4.3.8",
     "extract-zip": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "archiver": "5.3.0",
-    "async": "^2.6.1",
+    "async": "3.2.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "^8.4.0",
     "clean-stack": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "10.0.2",
     "clean-stack": "3.0.1",
-    "cron-validate": "^1.4.2",
+    "cron-validate": "1.4.3",
     "ed25519-supercop": "^2.0.1",
     "electron-alert": "0.1.13",
     "electron-log": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "app-builder-bin": "^3.5.13",
+    "app-builder-bin": "4.1.0",
     "electron": "13.4.0",
     "electron-builder": "22.11.7",
     "node-gyp": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "electron-root-path": "1.0.16",
     "electron-serve": "1.1.0",
     "electron-updater": "4.3.8",
-    "extract-zip": "^2.0.1",
+    "extract-zip": "2.0.1",
     "find-free-port": "^2.0.0",
     "github-markdown-css": "^4.0.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",


### PR DESCRIPTION
This PR hardcodes and updates package versions, also:
  - Fixes `Wine` release key expiration issue for `windows` docker container for `apt-get update`
  - Changes dependency from `node-pre-gyp` to `@mapbox/node-pre-gyp`. The non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will receive updates in the future https://github.com/mapbox/node-pre-gyp#special-note-on-previous-package
  - Removes redundant `async` dependency
  - Bumps electron version up to `13.6.1`
  
  **Depends** on this PRs:
  - https://github.com/bitfinexcom/bfx-report-express/pull/19
  - https://github.com/bitfinexcom/bfx-report/pull/251
  - https://github.com/bitfinexcom/bfx-reports-framework/pull/199
