### PR TITLE
Allow continuing when reporting errors

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 *Dockerfile*
 *docker-compose*
 lastCommit.json
+dev-app-update.yml
 dist
 bfx-reports-framework/db/*.db
 bfx-reports-framework/db/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ package-lock.json
 .env
 lastCommit.json
 electronEnv.json
+stub.AppImage

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ For Dev purpose to launch the Electron app locally might be used the following N
 npm start
 ```
 
+Also, there's available an option to debug the auto-update flow non-packaged build, in that case, just need to set the corresponding environment variable before running `npm start`:
+
+```console
+export IS_AUTO_UPDATE_BEING_TESTED=true
+```
+
 ### Launch build process
 
 For doing builds for other platforms please have [Multi Platform Build](https://www.electron.build/multi-platform-build) in consideration

--- a/dev-app-update.yml
+++ b/dev-app-update.yml
@@ -1,0 +1,7 @@
+provider: github
+repo: bfx-report-electron
+owner: bitfinexcom
+vPrefixedTagName: true
+channel: latest
+releaseType: draft
+updaterCacheDirName: bfx-report-electron-updater

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "compare-versions": "4.1.1",
     "cron-validate": "1.4.3",
     "ed25519-supercop": "2.0.1",
-    "electron-alert": "0.1.13",
+    "electron-alert": "0.1.20",
     "electron-log": "4.4.1",
     "electron-root-path": "1.0.16",
     "electron-serve": "1.1.0",

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -61,8 +61,8 @@ const _fireToast = (
   hooks = {}
 ) => {
   const {
-    onOpen = () => {},
-    onAfterClose = () => {}
+    didOpen = () => {},
+    didClose = () => {}
   } = { ...hooks }
 
   closeAlert(toast)
@@ -106,7 +106,7 @@ const _fireToast = (
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
 
-    type: 'info',
+    icon: 'info',
     title: 'Update',
     showConfirmButton: true,
     showCancelButton: false,
@@ -114,7 +114,7 @@ const _fireToast = (
 
     ...opts,
 
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -122,8 +122,8 @@ const _fireToast = (
 
       alert.browserWindow.hide()
     },
-    onOpen: () => {
-      onOpen(alert)
+    didOpen: () => {
+      didOpen(alert)
 
       if (
         !alert ||
@@ -132,7 +132,7 @@ const _fireToast = (
 
       alert.browserWindow.show()
     },
-    onClose: () => {
+    willClose: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -140,10 +140,10 @@ const _fireToast = (
 
       alert.browserWindow.hide()
     },
-    onAfterClose: () => {
+    didClose: () => {
       win.removeListener('closed', _closeAlert)
 
-      onAfterClose(alert)
+      didClose(alert)
     }
   }
 
@@ -260,7 +260,7 @@ const _autoUpdaterFactory = () => {
       ) {
         await _fireToast({
           title: 'Internet disconnected',
-          type: 'error',
+          icon: 'error',
           timer: 60000
         })
 
@@ -269,7 +269,7 @@ const _autoUpdaterFactory = () => {
 
       await _fireToast({
         title: 'Application update failed',
-        type: 'error',
+        icon: 'error',
         timer: 60000
       })
     } catch (err) {
@@ -289,7 +289,7 @@ const _autoUpdaterFactory = () => {
           timer: 10000
         },
         {
-          onOpen: (alert) => alert.showLoading()
+          didOpen: (alert) => alert.showLoading()
         }
       )
 
@@ -306,7 +306,7 @@ const _autoUpdaterFactory = () => {
         {
           title: `An update to v${version} is available`,
           text: 'Starting download...',
-          type: 'info',
+          icon: 'info',
           timer: 10000
         }
       )
@@ -341,7 +341,7 @@ const _autoUpdaterFactory = () => {
       await _fireToast(
         {
           title: 'No updates available',
-          type: 'success',
+          icon: 'success',
           timer: 10000
         }
       )
@@ -362,16 +362,16 @@ const _autoUpdaterFactory = () => {
       await _fireToast(
         {
           title: 'Downloading...',
-          type: 'info'
+          icon: 'info'
         },
         {
-          onOpen: (alert) => {
+          didOpen: (alert) => {
             _sendProgress(percent)
             alert.showLoading()
 
             isProgressToastEnabled = true
           },
-          onAfterClose: () => {
+          didClose: () => {
             isProgressToastEnabled = false
           }
         }
@@ -397,7 +397,7 @@ const _autoUpdaterFactory = () => {
         {
           title: `Update v${version} downloaded`,
           text: 'Should the app be updated right now?',
-          type: 'question',
+          icon: 'question',
           timer: 60000,
           showCancelButton: true
         }

--- a/src/auto-updater/toast-src/toast.css
+++ b/src/auto-updater/toast-src/toast.css
@@ -70,24 +70,29 @@ body.swal2-toast-shown .swal2-container {
   border-radius: 2px;
   background-color: #82baf6;
   transition: all 0.3s;
+  color: #102331;
+  box-shadow: none;
 }
 
 .swal2-actions .swal2-styled.swal2-confirm:hover,
 .swal2-actions .swal2-styled.swal2-confirm:focus,
 .swal2-actions .swal2-styled.swal2-confirm:active {
   background-color: #4c88c8;
+  box-shadow: none;
 }
 
 .swal2-styled.swal2-cancel {
   border-radius: 2;
   background-color: #172d3e;
   border: 1px solid #19354a;
+  box-shadow: none;
 }
 
 .swal2-actions .swal2-styled.swal2-cancel:hover,
 .swal2-actions .swal2-styled.swal2-cancel:focus,
 .swal2-actions .swal2-styled.swal2-cancel:active {
   background-color: #19354a;
+  box-shadow: none;
 }
 
 .swal2-popup.swal2-toast .swal2-icon {

--- a/src/auto-updater/toast-src/toast.css
+++ b/src/auto-updater/toast-src/toast.css
@@ -3,22 +3,47 @@ body .swal2-container {
   margin: 0;
 }
 
+body.swal2-toast-shown .swal2-container {
+  width: auto;
+}
+
+.swal2-popup.swal2-toast .swal2-html-container,
+.swal2-popup.swal2-toast .swal2-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 0;
+  margin-bottom: 0;
+  padding-top: 0px;
+  padding-bottom: 0px;
+  white-space: nowrap;
+}
+
 .swal2-popup.swal2-toast {
   flex-direction: row;
   box-shadow: none;
-  padding: 5px 20px;
+  padding: 0 20px;
   border-radius: 0;
   min-width: 300px;
   width: max-content;
-}
-
-.swal2-popup {
+  min-height: 44px;
+  justify-content: space-between;
+  align-items: center;
+  box-sizing: content-box;
   background-color: #172d3e;
 }
 
 .swal2-popup.swal2-toast .swal2-styled,
 .swal2-popup.swal2-toast .swal2-actions {
   margin-right: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.swal2-popup.swal2-toast .swal2-actions {
+  padding-right: 0;
 }
 
 .swal2-popup.swal2-toast .swal2-styled {
@@ -42,7 +67,7 @@ body .swal2-container {
 }
 
 .swal2-styled.swal2-confirm {
-  border-radius: 2;
+  border-radius: 2px;
   background-color: #82baf6;
   transition: all 0.3s;
 }
@@ -75,6 +100,10 @@ body .swal2-container {
 .swal2-actions.swal2-loading .swal2-styled.swal2-confirm {
   width: 1.8em;
   height: 1.8em;
+}
+
+.swal2-popup.swal2-toast .swal2-loader {
+  margin: 2px;
 }
 
 .process {

--- a/src/auto-updater/toast-src/toast.css
+++ b/src/auto-updater/toast-src/toast.css
@@ -1,4 +1,4 @@
-body {
+body .swal2-container {
   font-family: "Roboto", sans-serif;
   margin: 0;
 }
@@ -37,7 +37,7 @@ body {
   color: #82baf6;
 }
 
-.swal2-content {
+.swal2-html-container {
   color: #f5f8fa;
 }
 

--- a/src/auto-updater/toast-src/toast.js
+++ b/src/auto-updater/toast-src/toast.js
@@ -6,6 +6,21 @@ window.addEventListener('load', () => {
 
     const container = document.body
     const processWrapper = document.createElement('div')
+    const htmlContainers = document.getElementsByClassName('swal2-popup')
+    const actionContainers = document.getElementsByClassName('swal2-actions')
+    const titleContainers = document.getElementsByClassName('swal2-title')
+    const elemContainers = [
+      ...actionContainers,
+      ...titleContainers
+    ]
+
+    for (const container of htmlContainers) {
+      container.style.display = 'flex'
+      container.style.width = 'auto'
+    }
+    for (const container of elemContainers) {
+      container.style.display = 'flex'
+    }
 
     processWrapper.className = 'process'
     container.append(processWrapper)

--- a/src/change-sync-frequency.js
+++ b/src/change-sync-frequency.js
@@ -127,7 +127,7 @@ module.exports = () => {
 
   const timeFormatAlertOptions = {
     title: 'Set time format',
-    type: 'question',
+    icon: 'question',
     customClass: getAlertCustomClassObj({
       title: 'titleColor',
       container: 'textColor',
@@ -144,7 +144,7 @@ module.exports = () => {
       hours: 'Hours',
       days: 'Days'
     },
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (!timeFormatAlert.browserWindow) return
 
       timeFormatAlert.browserWindow.once('blur', closeTimeFormatAlert)
@@ -152,18 +152,18 @@ module.exports = () => {
   }
   const alertOptions = {
     title: 'Set sync frequency',
-    type: 'question',
-    customClass: {
+    icon: 'question',
+    customClass: getAlertCustomClassObj({
       title: 'titleColor',
-      content: 'textColor',
+      container: 'textColor',
       input: 'textColor rangeInput'
-    },
+    }),
     focusConfirm: true,
     showCancelButton: true,
     progressSteps: [1, 2],
     currentProgressStep: 1,
     input: 'range',
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (!alert.browserWindow) return
 
       alert.browserWindow.once('blur', closeAlert)

--- a/src/change-sync-frequency.js
+++ b/src/change-sync-frequency.js
@@ -23,6 +23,9 @@ const showErrorModalDialog = require('./show-error-modal-dialog')
 const pauseApp = require('./pause-app')
 const relaunch = require('./relaunch')
 const { getConfigsKeeperByName } = require('./configs-keeper')
+const getAlertCustomClassObj = require(
+  './helpers/get-alert-custom-class-obj'
+)
 
 const _getSchedulerRule = (timeFormat, alertRes) => {
   if (timeFormat.value === 'days') {
@@ -125,11 +128,11 @@ module.exports = () => {
   const timeFormatAlertOptions = {
     title: 'Set time format',
     type: 'question',
-    customClass: {
+    customClass: getAlertCustomClassObj({
       title: 'titleColor',
-      content: 'textColor',
+      container: 'textColor',
       input: 'textColor radioInput'
-    },
+    }),
     focusConfirm: true,
     showCancelButton: true,
     progressSteps: [1, 2],

--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -121,7 +121,6 @@ const manageNewGithubIssue = async (params) => {
     const {
       title,
       description,
-      isError,
       errBoxTitle,
       errBoxDescription
     } = getErrorDescription(params)
@@ -140,7 +139,6 @@ const manageNewGithubIssue = async (params) => {
       isExit,
       isReported
     } = await showModalDialog({
-      isError,
       errBoxTitle,
       errBoxDescription,
       mdIssue

--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -138,8 +138,7 @@ const manageNewGithubIssue = async (params) => {
 
     const {
       isExit,
-      isReported,
-      isIgnored
+      isReported
     } = await showModalDialog({
       isError,
       errBoxTitle,
@@ -147,11 +146,6 @@ const manageNewGithubIssue = async (params) => {
       mdIssue
     })
 
-    if (isIgnored) {
-      _unlockIssueManager()
-
-      return false
-    }
     if (isReported) {
       await openNewGithubIssue({
         title,

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -103,8 +103,10 @@ const _fireAlert = (params) => {
     focusConfirm: true,
     showConfirmButton: true,
     confirmButtonText: 'Report',
-    showCancelButton: true,
-    cancelButtonText: isError ? 'Exit' : 'Cancel',
+    showDenyButton: true,
+    denyButtonText: 'Cancel',
+    showCancelButton: isError,
+    cancelButtonText: 'Exit',
     timerProgressBar: false,
 
     willOpen: () => {
@@ -170,20 +172,19 @@ module.exports = async (params) => {
     const html = converter.makeHtml(mdIssue)
 
     const {
-      value
+      value,
+      isDismissed
     } = await _fireAlert({ isError, html })
 
     return {
-      isExit: isError,
-      isReported: value,
-      isIgnored: !isError && !value
+      isExit: isDismissed,
+      isReported: value
     }
   }
 
   const res = {
     isExit: true,
-    isReported: true,
-    isIgnored: false
+    isReported: true
   }
 
   // If called before the app ready event on Linux,

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -94,10 +94,10 @@ const _fireAlert = (params) => {
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
     customClass: getAlertCustomClassObj({
-      container: 'markdown-body'
+      htmlContainer: 'markdown-body'
     }),
 
-    type: 'question',
+    icon: 'question',
     title,
     html,
     focusConfirm: true,
@@ -107,7 +107,7 @@ const _fireAlert = (params) => {
     cancelButtonText: isError ? 'Exit' : 'Cancel',
     timerProgressBar: false,
 
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -115,7 +115,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onOpen: () => {
+    didOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -130,7 +130,7 @@ const _fireAlert = (params) => {
           : height
       })
     },
-    onClose: () => {
+    willClose: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -138,7 +138,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onAfterClose: () => {
+    didClose: () => {
       win.removeListener('closed', _close)
     }
   }

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -9,6 +9,9 @@ const { rootPath } = require('electron-root-path')
 
 const wins = require('../windows')
 const spawn = require('../helpers/spawn')
+const getAlertCustomClassObj = require(
+  '../helpers/get-alert-custom-class-obj'
+)
 const isMainWinAvailable = require(
   '../helpers/is-main-win-available'
 )
@@ -90,9 +93,9 @@ const _fireAlert = (params) => {
     position: 'center',
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
-    customClass: {
-      content: 'markdown-body'
-    },
+    customClass: getAlertCustomClassObj({
+      container: 'markdown-body'
+    }),
 
     type: 'question',
     title,

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -49,7 +49,6 @@ const converter = new Converter({
 const _fireAlert = (params) => {
   const {
     title = 'Should a bug report be submitted?',
-    isError,
     html
   } = params
   const win = wins.mainWindow
@@ -103,10 +102,8 @@ const _fireAlert = (params) => {
     focusConfirm: true,
     showConfirmButton: true,
     confirmButtonText: 'Report',
-    showDenyButton: true,
-    denyButtonText: 'Cancel',
-    showCancelButton: isError,
-    cancelButtonText: 'Exit',
+    showCancelButton: true,
+    cancelButtonText: 'Cancel',
     timerProgressBar: false,
 
     willOpen: () => {
@@ -159,7 +156,6 @@ const _fireAlert = (params) => {
 
 module.exports = async (params) => {
   const {
-    isError,
     errBoxTitle = 'Bug report',
     errBoxDescription = 'A new Github issue will be opened',
     mdIssue
@@ -172,12 +168,11 @@ module.exports = async (params) => {
     const html = converter.makeHtml(mdIssue)
 
     const {
-      value,
-      isDismissed
-    } = await _fireAlert({ isError, html })
+      value
+    } = await _fireAlert({ html })
 
     return {
-      isExit: isDismissed,
+      isExit: false,
       isReported: value
     }
   }

--- a/src/helpers/get-alert-custom-class-obj.js
+++ b/src/helpers/get-alert-custom-class-obj.js
@@ -1,0 +1,21 @@
+'use strict'
+
+module.exports = (props = {}) => {
+  const _container = props?.container ?? ''
+  delete props.container
+
+  return {
+    _container,
+    set container (val) {
+      if (val === 'noscrollbar') {
+        return
+      }
+
+      this._container = `${this._container} ${val}`
+    },
+    get container () {
+      return this._container
+    },
+    ...props
+  }
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,6 +13,7 @@ const isMainWinAvailable = require(
   './is-main-win-available'
 )
 const productName = require('./product-name')
+const getAlertCustomClassObj = require('./get-alert-custom-class-obj')
 
 module.exports = {
   getFreePort,
@@ -21,5 +22,6 @@ module.exports = {
   deserializeError,
   rm,
   isMainWinAvailable,
-  productName
+  productName,
+  getAlertCustomClassObj
 }

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -115,6 +115,11 @@ body::-webkit-scrollbar-thumb,
   border-left: .25em solid #19354a;
 }
 
+.radioInput,
+.rangeInput {
+  background: none;
+}
+
 .rangeInput {
   display: flex;
   align-items: center;

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -35,24 +35,33 @@ body::-webkit-scrollbar-thumb,
   border-radius: 2px;
   background-color: #82baf6;
   transition: all 0.3s;
+  color: #102331;
+  box-shadow: none;
 }
 
 .swal2-actions .swal2-styled.swal2-confirm:hover,
 .swal2-actions .swal2-styled.swal2-confirm:focus,
 .swal2-actions .swal2-styled.swal2-confirm:active {
   background-color: #4c88c8;
+  box-shadow: none;
 }
 
-.swal2-styled.swal2-cancel {
+.swal2-styled.swal2-cancel,
+.swal2-styled.swal2-deny {
   border-radius: 2px;
   background-color: #172d3e;
   border: 1px solid #19354a;
+  box-shadow: none;
 }
 
 .swal2-actions .swal2-styled.swal2-cancel:hover,
 .swal2-actions .swal2-styled.swal2-cancel:focus,
-.swal2-actions .swal2-styled.swal2-cancel:active {
+.swal2-actions .swal2-styled.swal2-cancel:active,
+.swal2-actions .swal2-styled.swal2-deny:hover,
+.swal2-actions .swal2-styled.swal2-deny:focus,
+.swal2-actions .swal2-styled.swal2-deny:active {
   background-color: #19354a;
+  box-shadow: none;
 }
 
 .markdown-body {

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -32,7 +32,7 @@ body::-webkit-scrollbar-thumb,
 }
 
 .swal2-styled.swal2-confirm {
-  border-radius: 2;
+  border-radius: 2px;
   background-color: #82baf6;
   transition: all 0.3s;
 }
@@ -44,7 +44,7 @@ body::-webkit-scrollbar-thumb,
 }
 
 .swal2-styled.swal2-cancel {
-  border-radius: 2;
+  border-radius: 2px;
   background-color: #172d3e;
   border: 1px solid #19354a;
 }

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -1,4 +1,4 @@
-body {
+body .swal2-container {
   font-family: "Roboto", sans-serif;
 }
 
@@ -57,7 +57,8 @@ body::-webkit-scrollbar-thumb,
 
 .markdown-body {
   background-color: #102331;
-  padding: 16px 16px 0;
+  padding: 16px;
+  font-size: 1em;
 }
 
 .markdown-body table {
@@ -184,7 +185,11 @@ body::-webkit-scrollbar-thumb,
   color: #82baf6;
 }
 
-.swal2-content,
+.swal2-html-container {
+  margin: 1em 1em .3em;
+}
+
+.swal2-html-container,
 .textColor {
   color: #f5f8fa;
 }

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -46,8 +46,7 @@ body::-webkit-scrollbar-thumb,
   box-shadow: none;
 }
 
-.swal2-styled.swal2-cancel,
-.swal2-styled.swal2-deny {
+.swal2-styled.swal2-cancel {
   border-radius: 2px;
   background-color: #172d3e;
   border: 1px solid #19354a;
@@ -56,10 +55,7 @@ body::-webkit-scrollbar-thumb,
 
 .swal2-actions .swal2-styled.swal2-cancel:hover,
 .swal2-actions .swal2-styled.swal2-cancel:focus,
-.swal2-actions .swal2-styled.swal2-cancel:active,
-.swal2-actions .swal2-styled.swal2-deny:hover,
-.swal2-actions .swal2-styled.swal2-deny:focus,
-.swal2-actions .swal2-styled.swal2-deny:active {
+.swal2-actions .swal2-styled.swal2-cancel:active {
   background-color: #19354a;
   box-shadow: none;
 }

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -105,11 +105,12 @@ const _fireAlert = (params) => {
     backdrop: 'rgba(0,0,0,0.0)',
     customClass: getAlertCustomClassObj({
       title: 'titleColor',
-      container: 'select-db-backup textColor',
+      container: 'textColor',
+      htmlContainer: 'select-db-backup ',
       input: 'textColor radioInput'
     }),
 
-    type: 'question',
+    icon: 'question',
     title,
     showConfirmButton: true,
     focusCancel: true,
@@ -121,7 +122,7 @@ const _fireAlert = (params) => {
     inputValue,
     inputOptions,
 
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -129,7 +130,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onOpen: () => {
+    didOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -144,7 +145,7 @@ const _fireAlert = (params) => {
           : height
       })
     },
-    onClose: () => {
+    willClose: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -152,7 +153,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onAfterClose: () => {
+    didClose: () => {
       win.removeListener('closed', _close)
     }
   }

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -14,6 +14,9 @@ const {
 const isMainWinAvailable = require(
   '../helpers/is-main-win-available'
 )
+const getAlertCustomClassObj = require(
+  '../helpers/get-alert-custom-class-obj'
+)
 const showMessageModalDialog = require(
   '../show-message-modal-dialog'
 )
@@ -100,11 +103,11 @@ const _fireAlert = (params) => {
     position: 'center',
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
-    customClass: {
+    customClass: getAlertCustomClassObj({
       title: 'titleColor',
-      content: 'select-db-backup textColor',
+      container: 'select-db-backup textColor',
       input: 'textColor radioInput'
-    },
+    }),
 
     type: 'question',
     title,

--- a/src/show-docs/index.js
+++ b/src/show-docs/index.js
@@ -11,6 +11,9 @@ const wins = require('../windows')
 const isMainWinAvailable = require(
   '../helpers/is-main-win-available'
 )
+const getAlertCustomClassObj = require(
+  '../helpers/get-alert-custom-class-obj'
+)
 const {
   closeAlert
 } = require('../modal-dialog-src/utils')
@@ -95,9 +98,9 @@ const _fireAlert = (params) => {
     position: 'center',
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
-    customClass: {
-      content: 'markdown-body'
-    },
+    customClass: getAlertCustomClassObj({
+      container: 'markdown-body'
+    }),
 
     type,
     title,

--- a/src/show-docs/index.js
+++ b/src/show-docs/index.js
@@ -99,7 +99,7 @@ const _fireAlert = (params) => {
     allowOutsideClick: false,
     backdrop: 'rgba(0,0,0,0.0)',
     customClass: getAlertCustomClassObj({
-      container: 'markdown-body'
+      htmlContainer: 'markdown-body'
     }),
 
     type,
@@ -111,7 +111,7 @@ const _fireAlert = (params) => {
     cancelButtonText: 'Cancel',
     timerProgressBar: false,
 
-    onBeforeOpen: () => {
+    willOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -119,7 +119,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onOpen: () => {
+    didOpen: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -134,7 +134,7 @@ const _fireAlert = (params) => {
           : height
       })
     },
-    onClose: () => {
+    willClose: () => {
       if (
         !alert ||
         !alert.browserWindow
@@ -142,7 +142,7 @@ const _fireAlert = (params) => {
 
       alert.browserWindow.hide()
     },
-    onAfterClose: () => {
+    didClose: () => {
       win.removeListener('closed', _close)
     }
   }

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -160,6 +160,8 @@ const _createChildWindow = async (
       winName
     },
     {
+      width,
+      height,
       minWidth: width,
       minHeight: height,
       x,


### PR DESCRIPTION
This PR allows continuing work with the app when reporting errors. The main changes:
  - Bumps `electron-alert` up to `v0.1.20`. The main reason is: the new version of `electron-alert` has bumped the version of [SweetAlert2](https://github.com/sweetalert2/sweetalert2) up to `v11` which has an option to add three buttons to a modal dialog. In this case, the idea is: when an error occurs show three btn `Report`/`Cancel`/`Exit` to provide users the ability to select what should be done, `Cancel` the modal dialog, or `Exit` the app
  - Migrate `electron-alert` styles/api to `v0.1.20`
  - Adds an option to debug auto-update flow non-packaged build. For this, just need to set the corresponding environment variable before running `npm start`: `export IS_AUTO_UPDATE_BEING_TESTED=true`
  - Adds separate btns to cancel error dialog or exit app for the `Open new GitHub issue` option
  - Fixes error window width in order to not has the width as a display screen by default

When the `Open new GitHub issue` option triggers manually via the menu bar shows the following modal dialog with two btns:

![Screenshot from 2022-08-09 09-51-43](https://user-images.githubusercontent.com/16489235/183591878-677f6887-4a54-48e4-9025-b78fe432ae70.png)

When an error occurs shows the following modal dialog with three btns:

![Screenshot from 2022-08-09 09-53-30](https://user-images.githubusercontent.com/16489235/183591919-fd11fda2-c3c6-4af8-8358-86755444b78a.png)

Related to the issue https://github.com/bitfinexcom/bfx-report-electron/issues/149
