### PR TITLE
Fix auto-update toast window styles

### DIFF
--- a/src/auto-updater/toast-src/toast.css
+++ b/src/auto-updater/toast-src/toast.css
@@ -31,6 +31,7 @@ body.swal2-toast-shown .swal2-container {
   align-items: center;
   box-sizing: content-box;
   background-color: #172d3e;
+  overflow: revert;
 }
 
 .swal2-popup.swal2-toast .swal2-styled,
@@ -44,6 +45,7 @@ body.swal2-toast-shown .swal2-container {
 
 .swal2-popup.swal2-toast .swal2-actions {
   padding-right: 0;
+  flex-wrap: nowrap;
 }
 
 .swal2-popup.swal2-toast .swal2-styled {
@@ -64,6 +66,7 @@ body.swal2-toast-shown .swal2-container {
 
 .swal2-html-container {
   color: #f5f8fa;
+  overflow: revert;
 }
 
 .swal2-styled.swal2-confirm {


### PR DESCRIPTION
This PR fixes auto-update toast window styles:
- wrong layout
![Screenshot from 2022-08-30 15-59-44](https://user-images.githubusercontent.com/16489235/187444334-58ddc2b5-576c-4a26-bd91-f961d619ab2d.png)

- would be:
![Screenshot from 2022-08-30 15-58-21](https://user-images.githubusercontent.com/16489235/187444434-e0ca0eac-e33a-427d-bf6a-985200db045a.png)
