### PR TITLE
Add ability to use BFX API Staging via GitHub Actions

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -16,6 +16,9 @@ on:
       isAutoUpdateDisabled:
         description: 'Is auto-update disabled (true / 1)?'
         required: false
+      isBfxApiStaging:
+        description: 'Is it necessary to use BFX API Staging? (true / 1)?'
+        required: false
 
 env:
   DOCKER_BUILDKIT: 1
@@ -45,6 +48,10 @@ jobs:
       name: Turn off auto-update
       run: |
         echo "IS_AUTO_UPDATE_DISABLED=1" >> $GITHUB_ENV
+    - if: contains(fromJson('["true", "1", true, 1]'), github.event.inputs.isBfxApiStaging)
+      name: Use BFX API Staging for queries
+      run: |
+        echo "IS_BFX_API_STAGING=1" >> $GITHUB_ENV
     - name: Cache Docker images
       uses: ScribeMD/docker-cache@0.1.4
       env:
@@ -103,6 +110,10 @@ jobs:
       name: Turn off auto-update
       run: |
         echo "IS_AUTO_UPDATE_DISABLED=1" >> $GITHUB_ENV
+    - if: contains(fromJson('["true", "1", true, 1]'), github.event.inputs.isBfxApiStaging)
+      name: Use BFX API Staging for queries
+      run: |
+        echo "IS_BFX_API_STAGING=1" >> $GITHUB_ENV
     - uses: actions/setup-node@v3
       with:
         node-version: 14.16.0


### PR DESCRIPTION
This PR adds ability to make releases using `GitHub Actions` against the BFX API Staging manually. To do this need to set `IS_BFX_API_STAGING` env var https://github.com/bitfinexcom/bfx-report-electron/blob/master/.env.example#L2

![Screenshot from 2023-01-23 11-52-45](https://user-images.githubusercontent.com/16489235/214015742-f1e23ce0-0f73-4e42-9726-046b01ce37e0.png)
