### PR TITLE
Bump electron version up to 21.3.3

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -116,7 +116,7 @@ jobs:
         echo "IS_BFX_API_STAGING=1" >> $GITHUB_ENV
     - uses: actions/setup-node@v3
       with:
-        node-version: 14.16.0
+        node-version: 16.20.0
     - name: Cache Electron binaries
       id: electron-cache
       uses: actions/cache@v3

--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -1,6 +1,6 @@
-FROM electronuserland/builder:14
+FROM electronuserland/builder:16
 
-ARG NODE_VERSION="14.16.0"
+ARG NODE_VERSION="16.20.0"
 
 ENV IS_BFX_API_STAGING=${IS_BFX_API_STAGING:-0}
 ENV IS_DEV_ENV=${IS_DEV_ENV:-0}

--- a/Dockerfile.mac-builder
+++ b/Dockerfile.mac-builder
@@ -1,6 +1,6 @@
-FROM electronuserland/builder:14
+FROM electronuserland/builder:16
 
-ARG NODE_VERSION="14.16.0"
+ARG NODE_VERSION="16.20.0"
 
 ENV IS_BFX_API_STAGING=${IS_BFX_API_STAGING:-0}
 ENV IS_DEV_ENV=${IS_DEV_ENV:-0}

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -1,6 +1,6 @@
-FROM electronuserland/builder:14
+FROM electronuserland/builder:16
 
-ARG NODE_VERSION="14.16.0"
+ARG NODE_VERSION="16.20.0"
 
 ENV IS_BFX_API_STAGING=${IS_BFX_API_STAGING:-0}
 ENV IS_DEV_ENV=${IS_DEV_ENV:-0}

--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -1,6 +1,6 @@
-FROM electronuserland/builder:14-wine
+FROM electronuserland/builder:16-wine
 
-ARG NODE_VERSION="14.16.0"
+ARG NODE_VERSION="16.20.0"
 
 ENV IS_BFX_API_STAGING=${IS_BFX_API_STAGING:-0}
 ENV IS_DEV_ENV=${IS_DEV_ENV:-0}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "electron-alert": "0.1.20",
     "electron-log": "4.4.1",
     "electron-root-path": "1.0.16",
-    "electron-serve": "1.1.0",
     "electron-updater": "5.3.0",
     "extract-zip": "2.0.1",
     "get-port": "6.1.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "electron-log": "4.4.1",
     "electron-root-path": "1.0.16",
     "electron-serve": "1.1.0",
-    "electron-updater": "5.0.4",
+    "electron-updater": "5.3.0",
     "extract-zip": "2.0.1",
     "get-port": "6.1.2",
     "github-markdown-css": "5.1.0",
@@ -37,8 +37,8 @@
   "devDependencies": {
     "@mapbox/node-pre-gyp": "1.0.6",
     "app-builder-bin": "4.1.0",
-    "electron": "13.6.9",
-    "electron-builder": "23.0.9",
+    "electron": "21.3.3",
+    "electron-builder": "23.6.0",
     "mocha": "10.2.0",
     "standard": "16.0.4"
   },

--- a/scripts/helpers/install-backend-deps.sh
+++ b/scripts/helpers/install-backend-deps.sh
@@ -58,7 +58,7 @@ function installBackendDeps {
   npm i --production --include=dev --no-audit --progress=false
   rm -rf "$ROOT/node_modules/ed25519-supercop/build"
   checkNodeModulesDir "$ROOT"
-  depsErr=$(npm ls --depth=0 --only=prod 2>&1 >/dev/null | grep -v "missing: eslint" || [[ $? == 1 ]])
+  depsErr=$(npm ls --depth=0 --only=prod 2>&1 >/dev/null | grep -E -v "missing: eslint|--omit=dev" || [[ $? == 1 ]])
   if [ -n "$depsErr" ]; then
     echo -e "$depsErr" >&2
     exit 1

--- a/scripts/helpers/install-nodejs.sh
+++ b/scripts/helpers/install-nodejs.sh
@@ -13,7 +13,7 @@ script as required NodeJS version!${COLOR_NORMAL}" >&2
   exit 1
 fi
 
-version="${1:-"14.16.0"}"
+version="${1:-"16.20.0"}"
 
 echo -e "\n${COLOR_BLUE}Installing the NodeJS v$version...${COLOR_NORMAL}"
 
@@ -29,7 +29,7 @@ unlink /usr/local/README.md
 npm config set unsafe-perm true
 
 npm cache clear --force
-npm install --global node-gyp@7.1.2
+npm install --global node-gyp@9.1.0
 npm config set node_gyp $(npm prefix -g)/lib/node_modules/node-gyp/bin/node-gyp.js
 
 echo -e "\n${COLOR_GREEN}The NodeJS has been installed successful${COLOR_NORMAL}"

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -103,6 +103,7 @@ const _fireToast = (
     backgroundColor: '#172d3e',
     darkTheme: false,
     height,
+    width: opts?.width ?? 800,
     parent: win,
     modal: false,
     webPreferences: {
@@ -165,6 +166,11 @@ const _fireToast = (
     sound
   )
 
+  ipcMain.on('auto-update-toast:width', (event, data) => {
+    alert.browserWindow?.setBounds({
+      width: Math.round(data?.width ?? 0)
+    })
+  })
   ipcMain.on(alert.uid + 'reposition', () => {
     const { x, y, width } = win.getContentBounds()
     const { width: alWidth } = alert.browserWindow.getContentBounds()

--- a/src/auto-updater/toast-src/toast.js
+++ b/src/auto-updater/toast-src/toast.js
@@ -53,6 +53,18 @@ window.addEventListener('load', () => {
         console.error(err)
       }
     })
+
+    let width = 0
+
+    for (const container of htmlContainers) {
+      width = Math.max(
+        width,
+        container.getBoundingClientRect().width ?? 0,
+        container.scrollWidth ?? 0
+      )
+    }
+
+    ipcRenderer.send('auto-update-toast:width', { width })
   } catch (err) {
     console.error(err)
   }

--- a/src/serve.js
+++ b/src/serve.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const electron = require('electron')
+const fsPromises = require('fs/promises')
+const path = require('path')
+
+// See https://cs.chromium.org/chromium/src/net/base/net_error_list.h
+const FILE_NOT_FOUND = -6
+
+const _getPath = async (filePath) => {
+  try {
+    const result = await fsPromises.stat(filePath)
+
+    if (result.isFile()) {
+      return filePath
+    }
+    if (result.isDirectory()) {
+      return _getPath(path.join(filePath, 'index.html'))
+    }
+  } catch (err) {}
+
+  return false
+}
+
+module.exports = (opts) => {
+  const {
+    directory,
+    partition,
+    scheme = 'app',
+    startRoute = 'index',
+    isCorsEnabled = true
+  } = opts ?? {}
+
+  if (!directory) {
+    throw new Error('The `directory` option is required')
+  }
+
+  const dirPath = path.resolve(
+    electron.app.getAppPath(),
+    directory
+  )
+
+  const handler = async (request, cd) => {
+    const indexPath = path.join(dirPath, 'index.html')
+    const filePath = path.join(
+      dirPath,
+      decodeURIComponent(new URL(request.url).pathname)
+    )
+    const resolvedPath = await _getPath(filePath)
+    const fileExtension = path.extname(filePath)
+
+    if (
+      resolvedPath ||
+      !fileExtension ||
+      fileExtension === '.html' ||
+      fileExtension === '.asar'
+    ) {
+      cd({ path: resolvedPath || indexPath })
+
+      return
+    }
+
+    cd({ error: FILE_NOT_FOUND })
+  }
+
+  electron.protocol.registerSchemesAsPrivileged([
+    {
+      scheme,
+      privileges: {
+        standard: true,
+        secure: true,
+        allowServiceWorkers: true,
+        supportFetchAPI: true,
+        corsEnabled: isCorsEnabled
+      }
+    }
+  ])
+  electron.app.on('ready', () => {
+    const session = partition
+      ? electron.session.fromPartition(partition)
+      : electron.session.defaultSession
+
+    session.protocol.registerFileProtocol(scheme, handler)
+  })
+
+  return async (win) => {
+    await win.loadURL(`${scheme}://${startRoute ?? dirPath}`)
+  }
+}


### PR DESCRIPTION
This PR bumps electron version up to `v21.3.3` to have nodejs `v16` under the hood to resolve the ability to build UI and electron releases using the same nodejs version

---

Basic changes:
- Bumps electron version up to `v21.3.3`, electron-updater up to `v5.3.0`, electron-builder up to `v23.6.0`
- Bumps nodejs version up to `v16.20.0` for GitHub Actions
- Bumps nodejs version up to `v16.20.0` for Docker containers
- Fixes backend deps installation script
- Fixes ability to serve ui static files
- Fixes auto-update toast width
