### PR TITLE
Fix issue with reloading ui page via menu bar opts

### DIFF
--- a/src/trigger-electron-load.js
+++ b/src/trigger-electron-load.js
@@ -14,9 +14,11 @@ const triggerElectronLoadStr = fs.readFileSync(
 )
 
 const placeholderPattern = /\$\{apiPort\}/
+let cachedExpressApiPort = null
 
 module.exports = (args) => {
-  const { expressApiPort = null } = args ?? {}
+  const { expressApiPort = cachedExpressApiPort } = args ?? {}
+  cachedExpressApiPort = expressApiPort
   const scriptStr = triggerElectronLoadStr.replace(
     placeholderPattern,
     expressApiPort


### PR DESCRIPTION
This PR fixes issue with reloading UI page via the menu bar options. In the electron env need to `trigger-electron-load` event after running `Force Reload` and `Reload` menu commands with express api port