### PR TITLE
Add note to app that bfx api staging is used

### DIFF
--- a/src/error-manager/github-issue-template.md
+++ b/src/error-manager/github-issue-template.md
@@ -16,6 +16,7 @@ ${description}
 | CPUs | ${cpuModel} x ${cpuCount} |
 | RAM | ${totalRamGb}GB (${freeRamGb}GB free) |
 | App RAM limit | ${ramLimitMb}Mb (${usedRamMb}MB used) |
+| Is BFX API Staging used | ${isBfxApiStagingUsed} |
 
 <details>
 

--- a/src/error-manager/render-markdown-template.js
+++ b/src/error-manager/render-markdown-template.js
@@ -42,13 +42,14 @@ const _renderMarkdownTemplate = (
   const str = template.replace(placeholderPattern, (match) => {
     const propName = match.replace('${', '').replace('}', '')
 
+    if (typeof params?.[propName] === 'boolean') {
+      params[propName] = params[propName]
+        ? 'Yes'
+        : 'No'
+    }
     if (
-      !params ||
-      typeof params !== 'object' ||
-      (
-        !Number.isFinite(params[propName]) &&
-        typeof params[propName] !== 'string'
-      )
+      !Number.isFinite(params?.[propName]) &&
+      typeof params?.[propName] !== 'string'
     ) {
       return ''
     }

--- a/src/helpers/get-debug-info.js
+++ b/src/helpers/get-debug-info.js
@@ -9,6 +9,7 @@ const { getAppUpdateConfigSync } = require('../auto-updater')
 
 const packageJson = require(path.join(appDir, 'package.json'))
 const productName = require('./product-name')
+const isBfxApiStaging = require('./is-bfx-api-staging')
 
 let lastCommit = { hash: '-', date: '-' }
 
@@ -114,6 +115,10 @@ module.exports = (eol = os.EOL) => {
   )
     ? `https://${provider}.com/${owner}/${repo}`
     : repository
+  const isBfxApiStagingUsed = isBfxApiStaging()
+  const bfxApiStagingDetail = isBfxApiStagingUsed
+    ? `${eol} Is BFX API Staging used: Yes`
+    : ''
 
   const detail = `\
 Version: ${version}${eol}\
@@ -125,6 +130,7 @@ Node.js: ${nodeVersion}${eol}\
 V8: ${v8Version}${eol}\
 OS version: ${osVersion}${eol}\
 OS release: ${osType} ${osArch} ${osRelease}\
+${bfxApiStagingDetail}
 `
 
   return {
@@ -150,6 +156,7 @@ OS release: ${osType} ${osArch} ${osRelease}\
     usedRamMb,
     cpuModel,
     cpuCount,
+    isBfxApiStagingUsed,
     detail
   }
 }

--- a/src/helpers/get-debug-info.js
+++ b/src/helpers/get-debug-info.js
@@ -117,7 +117,7 @@ module.exports = (eol = os.EOL) => {
     : repository
   const isBfxApiStagingUsed = isBfxApiStaging()
   const bfxApiStagingDetail = isBfxApiStagingUsed
-    ? `${eol} Is BFX API Staging used: Yes`
+    ? `${eol}Is BFX API Staging used: Yes`
     : ''
 
   const detail = `\

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -15,6 +15,7 @@ const isMainWinAvailable = require(
 const productName = require('./product-name')
 const getAlertCustomClassObj = require('./get-alert-custom-class-obj')
 const parseEnvValToBool = require('./parse-env-val-to-bool')
+const isBfxApiStaging = require('./is-bfx-api-staging')
 
 module.exports = {
   getFreePort,
@@ -25,5 +26,6 @@ module.exports = {
   isMainWinAvailable,
   productName,
   getAlertCustomClassObj,
-  parseEnvValToBool
+  parseEnvValToBool,
+  isBfxApiStaging
 }

--- a/src/helpers/is-bfx-api-staging.js
+++ b/src/helpers/is-bfx-api-staging.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const { rootPath } = require('electron-root-path')
+const path = require('path')
+
+const reportServiceConfig = require(path.join(
+  rootPath,
+  'bfx-reports-framework/config/service.report.json'
+))
+const pattern = /(staging)|(test)/i
+
+module.exports = () => {
+  const { restUrl } = reportServiceConfig ?? {}
+
+  return !!(
+    restUrl &&
+    typeof restUrl === 'string' &&
+    pattern.test(restUrl)
+  )
+}

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -23,6 +23,7 @@ const {
   hideWindow,
   centerWindow
 } = require('./helpers/manage-window')
+const isBfxApiStaging = require('./helpers/is-bfx-api-staging')
 
 const publicDir = path.join(__dirname, '../bfx-report-ui/build')
 const loadURL = serve({ directory: publicDir })
@@ -221,6 +222,11 @@ const createMainWindow = async ({
 
   if (isDevEnv) {
     wins.mainWindow.webContents.openDevTools()
+  }
+  if (isBfxApiStaging()) {
+    const title = wins.mainWindow.getTitle()
+
+    wins.mainWindow.setTitle(`${title} - BFX API STAGING USED`)
   }
 
   createMenu({ pathToUserData, pathToUserDocuments })


### PR DESCRIPTION
This PR adds a note to the electron app that BFX API Staging is used

---

Basic changes:
- adds a note to the `title` of the app
- adds a note to the `About` modal window
- adds a note to the debug info of the GitHub issue template

Examples of layouts:
![Screenshot from 2023-05-25 12-44-46](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/ce0589fb-1a2e-4658-8cb5-57c9a345bb26)
![Screenshot from 2023-05-25 12-45-13](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/2afc0a27-54cb-4a8d-a8e8-dcd5aa9cde18)
![Screenshot from 2023-05-25 12-45-54](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/efd13bbc-4d37-4219-ab72-9b17a3359a7a)
![Screenshot from 2023-05-25 13-13-11](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/b31fec84-794c-4399-a9ef-3d3986a38bfb)





