### PR TITLE
Release version 4.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.0] - 2023-06-21
+
+### Added
+
+- Added currency movement info endpoint https://docs.bitfinex.com/reference/movement-info. Due to the changed signatures of the `bitfinex-api-node` library methods in the new major version, to add this endpoint, the way of passing parameters to all bfx api methods is also changed/refactored. PRs: [bfx-report#297](https://github.com/bitfinexcom/bfx-report/pull/297), [bfx-reports-framework#287](https://github.com/bitfinexcom/bfx-reports-framework/pull/287)
+- Added ability to return the `timestamp` when the last sync was launched to add this info to the layouts of the new design. PR: [bfx-reports-framework#289](https://github.com/bitfinexcom/bfx-reports-framework/pull/289)
+- Added the possibility of removing registered accounts from the main `Sign In` screen. PR: [bfx-report-ui#662](https://github.com/bitfinexcom/bfx-report-ui/pull/662)
+- Added the possibility of creating/updating sub-accounts for password protected users. PR: [bfx-report-ui#663](https://github.com/bitfinexcom/bfx-report-ui/pull/663)
+
+### Changed
+
+- Prevented proxying all `HTML` of the `BFX API` error. PR: [bfx-report#299](https://github.com/bitfinexcom/bfx-report/pull/299)
+- Enhanced `Reports` tables representation according to the latest design updates. PR: [bfx-report-ui#664](https://github.com/bitfinexcom/bfx-report-ui/pull/664)
+
+### Fixed
+
+- Fixed `BFX API` error handling due to the last major changes of the rest-api lib: https://github.com/bitfinexcom/bfx-api-node-rest/blame/master/lib/rest2.js#LL157C14-L170C4. PRs: [bfx-report#298](https://github.com/bitfinexcom/bfx-report/pull/298), [bfx-report#300](https://github.com/bitfinexcom/bfx-report/pull/300)
+- Fixed `sub-account` updating for password-protected account, it's necessary to pass the password to the master account if it's passed in the request. PR: [bfx-reports-framework#288](https://github.com/bitfinexcom/bfx-reports-framework/pull/288)
+
 ## [4.7.1] - 2023-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.0] - 2023-07-05
+
+### Added
+
+- Added ability to fetch `Weighted Averages` data from the `BFX API` using `v2/auth/r/trades/calc` endpoint for hosted version. PRs: [bfx-report#306](https://github.com/bitfinexcom/bfx-report/pull/306), [bfx-report#307](https://github.com/bitfinexcom/bfx-report/pull/307), [bfx-report#310](https://github.com/bitfinexcom/bfx-report/pull/310), [bfx-report#311](https://github.com/bitfinexcom/bfx-report/pull/311), [bfx-reports-framework#292](https://github.com/bitfinexcom/bfx-reports-framework/pull/292)
+
+### Changed
+
+- Reworked navigation for the `Ledgers`, `Trades`, `Orders` and `Positions` reports as separate sub-sections in the `My History` menu instead of tabs in the `Ledgers & Trading` sub-section. PR: [bfx-report-ui#673](https://github.com/bitfinexcom/bfx-report-ui/pull/673)
+- Reworked `Weighted Averages` report representation. PRs: [bfx-report-ui#674](https://github.com/bitfinexcom/bfx-report-ui/pull/674), [bfx-report-ui#677](https://github.com/bitfinexcom/bfx-report-ui/pull/677), [bfx-report-ui#678](https://github.com/bitfinexcom/bfx-report-ui/pull/678)
+
+### Fixed
+
+- Fixed the issue with the active state losing in the `Wallets` section when switching to the `Movements` tab. PR: [bfx-report-ui#669](https://github.com/bitfinexcom/bfx-report-ui/pull/669)
+- Fixed issues with the incorrect accounts registration type detection. PR: [bfx-report-ui#670](https://github.com/bitfinexcom/bfx-report-ui/pull/670)
+- Fixed the `Export` option unavailability in the top navigation menu and showing `Start Sync` only in the `framework mode`. PR: [bfx-report-ui#672](https://github.com/bitfinexcom/bfx-report-ui/pull/672)
+
 ## [4.8.1] - 2023-06-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.9.1] - 2023-07-12
+
+### Added
+
+- Added `last/first` trades timestamps into the `Weighted Averages` report for the framework mode. PRs: [bfx-report#315](https://github.com/bitfinexcom/bfx-report/pull/315), [bfx-reports-framework#299](https://github.com/bitfinexcom/bfx-reports-framework/pull/299)
+
+### Fixed
+
+- Added `Rate Limit` router to control `BFX API` requests bandwidth to resolve the long timeout issue and help users to go through the data sync. Bumped API call timeout to `90s`. Reduced redundant `positionsAudit` calls to facilitate sync. Fixed stuck event loop to fix `WS` timeout on big data. PRs: [bfx-report#314](https://github.com/bitfinexcom/bfx-report/pull/314), [bfx-reports-framework#298](https://github.com/bitfinexcom/bfx-reports-framework/pull/298)
+
 ## [4.9.0] - 2023-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.8.1] - 2023-06-22
+
+### Fixed
+
+- Fixed issue with passing symbol parameter for `Order Trades` due to the last major changes of the `BFX API` [library](https://github.com/bitfinexcom/bfx-api-node-rest/blob/master/lib/rest2.js#L918). PR: [bfx-report#303](https://github.com/bitfinexcom/bfx-report/pull/303)
+- Reverted [(improvements) Reports tables representation](https://github.com/bitfinexcom/bfx-report-ui/pull/664) due to an issue with table scroll. PR: [bfx-report-ui#667](https://github.com/bitfinexcom/bfx-report-ui/pull/667)
+
 ## [4.8.0] - 2023-06-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.8.1",
+  "version": "4.9.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.9.0",
+  "version": "4.9.1",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.7.1",
+  "version": "4.8.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",


### PR DESCRIPTION
## [4.9.1] - 2023-07-12

### Added

- Added `last/first` trades timestamps into the `Weighted Averages` report for the framework mode. PRs: [bfx-report#315](https://github.com/bitfinexcom/bfx-report/pull/315), [bfx-reports-framework#299](https://github.com/bitfinexcom/bfx-reports-framework/pull/299)

### Fixed

- Added `Rate Limit` router to control `BFX API` requests bandwidth to resolve the long timeout issue and help users to go through the data sync. Bumped API call timeout to `90s`. Reduced redundant `positionsAudit` calls to facilitate sync. Fixed stuck event loop to fix `WS` timeout on big data. PRs: [bfx-report#314](https://github.com/bitfinexcom/bfx-report/pull/314), [bfx-reports-framework#298](https://github.com/bitfinexcom/bfx-reports-framework/pull/298)
