### PR TITLE
Fix max listeners exceeded warning

### DIFF
--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -23,6 +23,10 @@ const {
   closeAlert
 } = require('../modal-dialog-src/utils')
 const parseEnvValToBool = require('../helpers/parse-env-val-to-bool')
+const {
+  WINDOW_EVENT_NAMES,
+  addOnceProcEventHandler
+} = require('../window-event-manager')
 
 const isAutoUpdateDisabled = parseEnvValToBool(process.env.IS_AUTO_UPDATE_DISABLED)
 
@@ -90,9 +94,10 @@ const _fireToast = (
   const alert = new Alert([fonts, style, script])
   toast = alert
 
-  const _closeAlert = () => closeAlert(alert)
-
-  win.once('closed', _closeAlert)
+  const eventHandlerCtx = addOnceProcEventHandler(
+    WINDOW_EVENT_NAMES.CLOSED,
+    () => closeAlert(alert)
+  )
 
   const bwOptions = {
     frame: false,
@@ -151,7 +156,7 @@ const _fireToast = (
       alert.browserWindow.hide()
     },
     didClose: () => {
-      win.removeListener('closed', _closeAlert)
+      eventHandlerCtx.removeListener()
 
       didClose(alert)
     }

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -57,13 +57,11 @@ const script = `<script type="text/javascript">${toastScript}</script>`
 const sound = { freq: 'F2', type: 'triange', duration: 1.5 }
 
 const _sendProgress = (progress) => {
-  if (
-    !toast ||
-    !toast.browserWindow ||
-    !Number.isFinite(progress)
-  ) return
+  if (!Number.isFinite(progress)) {
+    return
+  }
 
-  toast.browserWindow.webContents.send(
+  toast?.browserWindow?.webContents.send(
     'progress',
     progress
   )
@@ -392,13 +390,15 @@ const _autoUpdaterFactory = () => {
   })
   autoUpdater.on('download-progress', async (progressObj) => {
     try {
-      const { percent } = { ...progressObj }
+      const { percent } = progressObj ?? {}
 
       if (isProgressToastEnabled) {
         _sendProgress(percent)
 
         return
       }
+
+      isProgressToastEnabled = true
 
       await _fireToast(
         {
@@ -409,8 +409,6 @@ const _autoUpdaterFactory = () => {
           didOpen: (alert) => {
             _sendProgress(percent)
             alert.showLoading()
-
-            isProgressToastEnabled = true
           },
           didClose: () => {
             isProgressToastEnabled = false

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -18,6 +18,10 @@ const isMainWinAvailable = require(
 const {
   closeAlert
 } = require('../modal-dialog-src/utils')
+const {
+  WINDOW_EVENT_NAMES,
+  addOnceProcEventHandler
+} = require('../window-event-manager')
 
 const mdStyle = fs.readFileSync(path.join(
   rootPath, 'node_modules', 'github-markdown-css/github-markdown.css'
@@ -69,9 +73,11 @@ const _fireAlert = (params) => {
   const maxHeight = Math.floor(screenHeight * 0.90)
 
   const alert = new Alert([mdS, fonts, style, script])
-  const _close = () => closeAlert(alert)
 
-  win.once('closed', _close)
+  const eventHandlerCtx = addOnceProcEventHandler(
+    WINDOW_EVENT_NAMES.CLOSED,
+    () => closeAlert(alert)
+  )
 
   const bwOptions = {
     frame: false,
@@ -138,7 +144,7 @@ const _fireAlert = (params) => {
       alert.browserWindow.hide()
     },
     didClose: () => {
-      win.removeListener('closed', _close)
+      eventHandlerCtx.removeListener()
     }
   }
 

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -26,6 +26,10 @@ const {
 const {
   DbRestoringError
 } = require('../errors')
+const {
+  WINDOW_EVENT_NAMES,
+  addOnceProcEventHandler
+} = require('../window-event-manager')
 
 const fontsStyle = fs.readFileSync(path.join(
   rootPath, 'bfx-report-ui/build/fonts/roboto.css'
@@ -79,9 +83,11 @@ const _fireAlert = (params) => {
   const maxHeight = Math.floor(screenHeight * 0.90)
 
   const alert = new Alert([fonts, style, script])
-  const _close = () => closeAlert(alert)
 
-  win.once('closed', _close)
+  const eventHandlerCtx = addOnceProcEventHandler(
+    WINDOW_EVENT_NAMES.CLOSED,
+    () => closeAlert(alert)
+  )
 
   const bwOptions = {
     resizable: true,
@@ -154,7 +160,7 @@ const _fireAlert = (params) => {
       alert.browserWindow.hide()
     },
     didClose: () => {
-      win.removeListener('closed', _close)
+      eventHandlerCtx.removeListener()
     }
   }
 

--- a/src/show-docs/index.js
+++ b/src/show-docs/index.js
@@ -23,6 +23,10 @@ const mdUserManual = fs.readFileSync(
   path.join(rootPath, 'docs/user-manual.md'),
   'utf8'
 )
+const {
+  WINDOW_EVENT_NAMES,
+  addOnceProcEventHandler
+} = require('../window-event-manager')
 
 const mdStyle = fs.readFileSync(path.join(
   rootPath, 'node_modules', 'github-markdown-css/github-markdown.css'
@@ -75,9 +79,11 @@ const _fireAlert = (params) => {
   const maxHeight = Math.floor(screenHeight * 0.90)
 
   const alert = new Alert([mdS, fonts, style, script])
-  const _close = () => closeAlert(alert)
 
-  win.once('closed', _close)
+  const eventHandlerCtx = addOnceProcEventHandler(
+    WINDOW_EVENT_NAMES.CLOSED,
+    () => closeAlert(alert)
+  )
 
   const bwOptions = {
     frame: false,
@@ -143,7 +149,7 @@ const _fireAlert = (params) => {
       alert.browserWindow.hide()
     },
     didClose: () => {
-      win.removeListener('closed', _close)
+      eventHandlerCtx.removeListener()
     }
   }
 

--- a/src/window-event-manager/index.js
+++ b/src/window-event-manager/index.js
@@ -1,0 +1,93 @@
+'use strict'
+
+const wins = require('../windows')
+
+const WINDOW_EVENT_NAMES = {
+  CLOSED: 'closed'
+}
+
+const windowMap = new Map()
+
+const addOnceProcEventHandler = (eventName, handler, window) => {
+  const _window = window ?? wins.mainWindow
+
+  if (
+    !_window ||
+    !eventName ||
+    typeof eventName !== 'string' ||
+    typeof handler !== 'function'
+  ) {
+    return {
+      isAdded: false,
+      removeListener: () => {}
+    }
+  }
+
+  const handlerSet = _setWinEventHandler(eventName, handler, window)
+
+  const ctx = {
+    isAdded: true,
+    removeListener: () => handlerSet.delete(handler)
+  }
+
+  return ctx
+}
+
+const _setWinEventHandler = (eventName, handler, window) => {
+  const winEventHandlerMap = _getWinEventHandlerMap(window)
+  const foundHandlerSet = winEventHandlerMap.get(eventName)?.handlerSet
+
+  if (foundHandlerSet instanceof Set) {
+    foundHandlerSet.add(handler)
+
+    return foundHandlerSet
+  }
+
+  const handlerSet = new Set([handler])
+  const rootHandler = () => {
+    winEventHandlerMap.delete(eventName)
+
+    for (const handler of handlerSet) {
+      try {
+        handlerSet.delete(handler)
+
+        const res = handler()
+
+        if (!(res instanceof Promise)) {
+          return
+        }
+
+        res.then(() => {}, (err) => { console.error(err) })
+      } catch (err) {
+        console.error(err)
+      }
+    }
+  }
+
+  window.once(eventName, rootHandler)
+  winEventHandlerMap.set(eventName, {
+    rootHandler,
+    handlerSet
+  })
+
+  return handlerSet
+}
+
+const _getWinEventHandlerMap = (window) => {
+  const foundWinEventHandlerMap = windowMap.get(window)
+
+  if (foundWinEventHandlerMap instanceof Map) {
+    return foundWinEventHandlerMap
+  }
+
+  const winEventHandlerMap = new Map()
+  windowMap.set(window, winEventHandlerMap)
+
+  return winEventHandlerMap
+}
+
+module.exports = {
+  WINDOW_EVENT_NAMES,
+
+  addOnceProcEventHandler
+}

--- a/src/window-event-manager/index.js
+++ b/src/window-event-manager/index.js
@@ -23,7 +23,7 @@ const addOnceProcEventHandler = (eventName, handler, window) => {
     }
   }
 
-  const handlerSet = _setWinEventHandler(eventName, handler, window)
+  const handlerSet = _setWinEventHandler(eventName, handler, _window)
 
   const ctx = {
     isAdded: true,


### PR DESCRIPTION
This PR fixes the https://github.com/bitfinexcom/bfx-report-electron/issues/215 related to `MaxListenersExceededWarning` warning for the electron windows

---

Basic changes:
- Adds manager for `closed` window event being `once` bubbled, for better handling
- Fixes download progress showing for the auto-update in cases when the event happens faster than the `alert` fires