### PR TITLE
Provide 10min express server timeouts

### DIFF
--- a/server.js
+++ b/server.js
@@ -127,7 +127,9 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
 
     process.env.NODE_CONFIG = JSON.stringify({
       app: {
-        port: expressApiPort
+        port: expressApiPort,
+        httpRpcTimeout: 10 * 60 * 1000,
+        wsRpcTimeout: 10 * 60 * 1000
       },
       grenacheClient: {
         grape


### PR DESCRIPTION
This PR provides `10min` express server timeouts for complicated reports which can have a lot of internal calls to the `BFX API` that can take significant time

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report-express/pull/31
