### PR TITLE
Prevent showing error modal dialog due to inet issue

### DIFF
--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -82,7 +82,8 @@ const _isLogSkipped = (log) => {
       str.includes('contextIsolation is deprecated') ||
       str.includes('ERR_INTERNET_DISCONNECTED') ||
       // Skip error when can't get code signature on mac
-      str.includes('Could not get code signature')
+      str.includes('Could not get code signature') ||
+      str.includes('ERR_BFX_API_SERVER_IS_NOT_AVAILABLE')
     )
   )
 }


### PR DESCRIPTION
This PR prevents showing error modal dialog due to inet issue

---

When the sync starts we send a ping request to bfx api to check that api is available

https://github.com/bitfinexcom/bfx-reports-framework/blob/master/workers/loc.api/sync/index.js#L127
https://github.com/bitfinexcom/bfx-reports-framework/blob/master/workers/loc.api/service.report.framework.js#L258
The idea is to not show error modal dialog for issues, just show error toast via UI when fetching the corresponding error with progress event via WS

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-reports-framework/pull/317
