### PR TITLE
Use lib-js-util-base instead of lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "github-markdown-css": "5.1.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "4.1.0",
-    "lodash": "4.17.21",
+    "lib-js-util-base": "git+https://github.com/bitfinexcom/lib-js-util-base.git",
     "new-github-issue-url": "0.2.1",
     "showdown": "2.0.3",
     "truncate-utf8-bytes": "1.0.2",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { pick } = require('lodash')
+const { pick } = require('lib-js-util-base')
 const { fork } = require('child_process')
 const path = require('path')
 const EventEmitter = require('events')

--- a/src/configs-keeper.js
+++ b/src/configs-keeper.js
@@ -3,7 +3,7 @@
 const { promisify } = require('util')
 const path = require('path')
 const fs = require('fs')
-const { cloneDeep } = require('lodash')
+const { cloneDeep } = require('lib-js-util-base')
 
 const {
   writeFileSync,

--- a/src/helpers/__test__/ports.spec.js
+++ b/src/helpers/__test__/ports.spec.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const { isObject } = require('lodash')
 const assert = require('assert').strict
 const { Server } = require('net')
 const DHT = require('bittorrent-dht')
@@ -15,7 +14,10 @@ const {
 const { getServerPromise } = require('../utils')
 
 const checkAssertions = (res) => {
-  assert.ok(isObject(res))
+  assert.ok(
+    res &&
+    typeof res === 'object'
+  )
   assert.ok(
     [
       'grape1DhtPort',


### PR DESCRIPTION
This PR adds ability to use [lib-js-util-base](https://github.com/bitfinexcom/lib-js-util-base) lib instead of the `lodash`

---

Base changes:
- uses `lib-js-util-base` lib instead of `lodash`
- removes `lodash.isObject` usage as redundant and not used anywhere
