### PR TITLE
Set dependabot against staging branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    target-branch: "staging"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "thursday"
+      time: "00:00"
+      timezone: "Etc/UTC"
+    commit-message:
+      prefix: "[npm] "
+    labels:
+      - "npm"
+      - "dependencies"


### PR DESCRIPTION
This PR sets the [dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file) against the `stagin` branch to not trigger test-runner workflow

![Screenshot from 2023-10-18 12-32-13](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/b2ee4bed-bdeb-4887-a7f3-1c1ba7150d74)

