### PR TITLE
Resolve dependabot dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "app-builder-bin": "4.2.0",
     "cross-env": "7.0.3",
     "electron": "27.2.0",
-    "electron-builder": "24.8.1",
+    "electron-builder": "24.10.0",
     "mocha": "10.2.0",
     "standard": "17.1.0",
     "wdio-electron-service": "5.4.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "yauzl": "2.10.0"
   },
   "devDependencies": {
-    "@mapbox/node-pre-gyp": "1.0.6",
+    "@mapbox/node-pre-gyp": "1.0.11",
     "@wdio/cli": "8.22.1",
     "@wdio/junit-reporter": "8.21.0",
     "@wdio/local-runner": "8.22.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "electron": "27.0.4",
     "electron-builder": "24.8.1",
     "mocha": "10.2.0",
-    "standard": "16.0.4",
+    "standard": "17.1.0",
     "wdio-electron-service": "5.4.0"
   },
   "standard": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "archiver": "5.3.0",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "10.0.2",
-    "changelog-parser": "2.8.0",
+    "changelog-parser": "3.0.1",
     "clean-stack": "3.0.1",
     "compare-versions": "4.1.1",
     "cron-validate": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@wdio/spec-reporter": "8.21.0",
     "app-builder-bin": "4.2.0",
     "cross-env": "7.0.3",
-    "electron": "27.0.4",
+    "electron": "27.2.0",
     "electron-builder": "24.8.1",
     "mocha": "10.2.0",
     "standard": "17.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@wdio/local-runner": "8.22.1",
     "@wdio/mocha-framework": "8.22.0",
     "@wdio/spec-reporter": "8.21.0",
-    "app-builder-bin": "4.1.0",
+    "app-builder-bin": "4.2.0",
     "cross-env": "7.0.3",
     "electron": "27.0.4",
     "electron-builder": "24.8.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "electron-root-path": "1.0.16",
     "electron-updater": "5.3.0",
     "extract-zip": "2.0.1",
-    "get-port": "6.1.2",
+    "get-port": "7.0.0",
     "github-markdown-css": "5.1.0",
     "grenache-grape": "git+https://github.com/bitfinexcom/grenache-grape.git",
     "js-yaml": "4.1.0",

--- a/scripts/node/generate-mac-zipand-blockmap.js
+++ b/scripts/node/generate-mac-zipand-blockmap.js
@@ -3,6 +3,7 @@
 'use strict'
 
 const path = require('path')
+const { chmodSync } = require('fs')
 const {
   execSync
 } = require('child_process')
@@ -34,6 +35,10 @@ const APP_GENERATED_BINARY_PATH = path.join(
 const ymlPath = path.join(APP_DIST_PATH, `${channel}-mac.yml`)
 
 try {
+  // It's required as binary does not have an execute permission by default
+  // https://github.com/develar/app-builder/issues/97
+  chmodSync(appBuilderPath, '755')
+
   const output = execSync(`${appBuilderPath} blockmap --input=${APP_GENERATED_BINARY_PATH} --output=${APP_GENERATED_BINARY_PATH}.blockmap --compression=gzip`)
   const { sha512, size } = JSON.parse(output)
   const ymlData = {

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -180,7 +180,7 @@ const _fireToast = (
 
     const boundsOpts = {
       x: (x + width) - alWidth,
-      y: y,
+      y,
       height
     }
 

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -235,8 +235,6 @@ module.exports = (ipc) => {
         }
 
         ipc.send({ state: PROCESS_STATES.REMOVE_ALL_TABLES })
-
-        return
       }
     } catch (err) {
       console.error(err)

--- a/src/window-creators.js
+++ b/src/window-creators.js
@@ -74,9 +74,9 @@ const _createWindow = async (
     manage
   } = isMainWindow
     ? windowStateKeeper({
-        defaultWidth,
-        defaultHeight
-      })
+      defaultWidth,
+      defaultHeight
+    })
     : {}
   const _props = {
     autoHideMenuBar: true,


### PR DESCRIPTION
This PR resolves `dependabot` dependency updates:
- https://github.com/bitfinexcom/bfx-report-electron/pull/269
- https://github.com/bitfinexcom/bfx-report-electron/pull/270
- https://github.com/bitfinexcom/bfx-report-electron/pull/272
- https://github.com/bitfinexcom/bfx-report-electron/pull/273
- https://github.com/bitfinexcom/bfx-report-electron/pull/280

---

Basic changes:
- Bump `app-builder-bin` up to 4.2.0 https://github.com/develar/app-builder/commits/v4.2.0
- Fix execute permission for `app-builder-bin`. Binary does not have an execute permission by default: https://github.com/develar/app-builder/issues/97
- Bump `standard` up to 17.1.0
- Fix code style considering standardjs 17
- Bump `electron` up to 27.2.0 https://releases.electronjs.org/release/compare/v27.0.4/v27.2.0
- Bump `electron-builder` up to 24.10.0 https://github.com/electron-userland/electron-builder/blob/869c7e4652a5d5a3562e25723d6cedd622ab657b/packages/electron-builder/CHANGELOG.md
- Bump `@mapbox/node-pre-gyp` up to 1.0.11 https://github.com/mapbox/node-pre-gyp/compare/v1.0.6...v1.0.11
- Bump `get-port` up to 7.0.0 https://github.com/sindresorhus/get-port/releases/tag/v7.0.0
- Bump `changelog-parser` up to 3.0.1 https://github.com/ungoldman/changelog-parser/compare/v2.8.0...v3.0.1
