### PR TITLE
Add support for PDF reports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ bfx-reports-framework/config/*.json
 bfx-reports-framework/config/facs/*.json
 bfx-reports-framework/logs/*.log
 bfx-reports-framework/csv
+bfx-reports-framework/report-files
 bfx-report-ui/build
 bfx-report-ui/bfx-report-express/logs/*.log
 bfx-report-ui/bfx-report-express/config/*.json

--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -155,6 +155,7 @@ module.exports = {
     '!bfx-reports-framework/*/*.sh',
     '!bfx-reports-framework/*.sh',
     '!bfx-reports-framework/.mocharc.json',
+    '!bfx-reports-framework/node_modules/phantomjs-prebuilt',
 
     '!**/.dockerignore',
     '!**/*Dockerfile*',

--- a/server.js
+++ b/server.js
@@ -78,7 +78,7 @@ const allowedProcessMessagesSet = _getAllowedStatesSet({
 
     'RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE',
 
-    'CREATE_PDF'
+    'REQUEST_PDF_CREATION'
   ]
 })
 const allowedProcessStatesSet = _getAllowedStatesSet({
@@ -96,8 +96,7 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
 
     'REQUEST_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE',
 
-    'CREATED_PDF_BUFFER',
-    'ERROR_PDF_CREATION'
+    'RESPONSE_PDF_CREATION'
   ]
 })
 

--- a/server.js
+++ b/server.js
@@ -76,7 +76,9 @@ const allowedProcessMessagesSet = _getAllowedStatesSet({
 
     'RESPONSE_GET_BACKUP_FILES_METADATA',
 
-    'RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE'
+    'RESPONSE_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE',
+
+    'CREATE_PDF'
   ]
 })
 const allowedProcessStatesSet = _getAllowedStatesSet({
@@ -92,7 +94,10 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
 
     'REQUEST_GET_BACKUP_FILES_METADATA',
 
-    'REQUEST_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE'
+    'REQUEST_UPDATE_USERS_SYNC_ON_STARTUP_REQUIRED_STATE',
+
+    'CREATED_PDF_BUFFER',
+    'ERROR_PDF_CREATION'
   ]
 })
 

--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ const {
 
 const {
   WrongPathToUserDataError,
-  WrongPathToUserCsvError,
+  WrongPathToUserReportFilesError,
   WrongSecretKeyError
 } = require('./src/errors')
 
@@ -99,7 +99,7 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
 ;(async () => {
   try {
     const pathToUserData = process.env.PATH_TO_USER_DATA
-    const pathToUserCsv = process.env.PATH_TO_USER_CSV
+    const pathToUserReportFiles = process.env.PATH_TO_USER_REPORT_FILES
     const schedulerRule = process.env.SCHEDULER_RULE
     const secretKey = process.env.SECRET_KEY
     const grape1DhtPort = process.env.GRAPE_1DHT_PORT
@@ -116,8 +116,8 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
     if (!pathToUserData) {
       throw new WrongPathToUserDataError()
     }
-    if (!pathToUserCsv) {
-      throw new WrongPathToUserCsvError()
+    if (!pathToUserReportFiles) {
+      throw new WrongPathToUserReportFilesError()
     }
 
     const grape = `http://127.0.0.1:${grape2ApiPort}`
@@ -162,7 +162,7 @@ const allowedProcessStatesSet = _getAllowedStatesSet({
       '--isSchedulerEnabled=true',
       '--isElectronjsEnv=true',
       '--isLoggerDisabled=false',
-      `--csvFolder=${pathToUserCsv}`,
+      `--reportFolder=${pathToUserReportFiles}`,
       `--tempFolder=${pathToUserData}/temp`,
       `--logsFolder=${pathToUserData}/logs`,
       `--dbFolder=${pathToUserData}`,

--- a/src/change-reports-folder.js
+++ b/src/change-reports-folder.js
@@ -2,7 +2,7 @@
 
 const { dialog, BrowserWindow } = require('electron')
 
-const { CSV_PATH_VERSION } = require('./const')
+const { REPORT_FILES_PATH_VERSION } = require('./const')
 
 const {
   InvalidFilePathError,
@@ -52,8 +52,8 @@ module.exports = ({ pathToUserDocuments }) => {
       await pauseApp()
       const isSaved = await getConfigsKeeperByName('main')
         .saveConfigs({
-          csvPathVersion: CSV_PATH_VERSION,
-          pathToUserCsv: filePaths[0]
+          reportFilesPathVersion: REPORT_FILES_PATH_VERSION,
+          pathToUserReportFiles: filePaths[0]
         })
 
       if (!isSaved) {

--- a/src/const.js
+++ b/src/const.js
@@ -6,7 +6,7 @@ const DB_FILE_NAME = 'db-sqlite_sync_m0.db'
 const DB_SHM_FILE_NAME = `${DB_FILE_NAME}-shm`
 const DB_WAL_FILE_NAME = `${DB_FILE_NAME}-wal`
 const SECRET_KEY_FILE_NAME = 'secret-key'
-const CSV_PATH_VERSION = 1
+const REPORT_FILES_PATH_VERSION = 1
 
 module.exports = {
   CONFIGS_FILE_NAME,
@@ -15,5 +15,5 @@ module.exports = {
   DB_SHM_FILE_NAME,
   DB_WAL_FILE_NAME,
   SECRET_KEY_FILE_NAME,
-  CSV_PATH_VERSION
+  REPORT_FILES_PATH_VERSION
 }

--- a/src/errors/index.js
+++ b/src/errors/index.js
@@ -65,8 +65,8 @@ class WrongPathToUserDataError extends BaseError {
   }
 }
 
-class WrongPathToUserCsvError extends BaseError {
-  constructor (message = 'ERR_WRONG_PATH_TO_USER_CSV') {
+class WrongPathToUserReportFilesError extends BaseError {
+  constructor (message = 'ERR_WRONG_PATH_TO_USER_REPORT_FILES') {
     super(message)
   }
 }
@@ -124,7 +124,7 @@ module.exports = {
   AppInitializationError,
   FreePortError,
   WrongPathToUserDataError,
-  WrongPathToUserCsvError,
+  WrongPathToUserReportFilesError,
   WrongSecretKeyError,
   ReportsFolderChangingError,
   SyncFrequencyChangingError,

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -3,7 +3,7 @@
 const { app } = require('electron')
 const path = require('path')
 
-const { CSV_PATH_VERSION } = require('./const')
+const { REPORT_FILES_PATH_VERSION } = require('./const')
 
 const triggerSyncAfterUpdates = require('./trigger-sync-after-updates')
 const triggerElectronLoad = require('./trigger-electron-load')
@@ -50,52 +50,26 @@ const { rule: schedulerRule } = require(
   '../bfx-reports-framework/config/schedule.json'
 )
 
-const _resetCsvPath = async (
+const _resetReportFilesPath = async (
   configsKeeper,
   opts = {}
 ) => {
   const {
-    pathToUserCsv,
-    isRelativeCsvPath
+    pathToUserReportFiles
   } = opts
 
-  // Need to use a new csv folder path for export
-  const storedPathToUserCsv = configsKeeper
-    .getConfigByName('pathToUserCsv')
-  const csvPathVersion = configsKeeper
-    .getConfigByName('csvPathVersion')
+  // Need to use a new report folder path for export
+  const reportFilesPathVersion = configsKeeper
+    .getConfigByName('reportFilesPathVersion') ??
+    configsKeeper.getConfigByName('csvPathVersion') // For back compatibility
 
-  if (csvPathVersion === CSV_PATH_VERSION) {
-    return
-  }
-  if (
-    (
-      isRelativeCsvPath &&
-      !storedPathToUserCsv.endsWith('csv')
-    ) ||
-    (
-      !isRelativeCsvPath &&
-      !storedPathToUserCsv.endsWith('bitfinex/reports')
-    ) ||
-    (
-      !isRelativeCsvPath &&
-      !path.isAbsolute(storedPathToUserCsv)
-    ) ||
-    (
-      isRelativeCsvPath &&
-      path.isAbsolute(storedPathToUserCsv)
-    )
-  ) {
-    await configsKeeper.saveConfigs({
-      csvPathVersion: CSV_PATH_VERSION,
-      pathToUserCsv
-    })
-
+  if (reportFilesPathVersion === REPORT_FILES_PATH_VERSION) {
     return
   }
 
   await configsKeeper.saveConfigs({
-    csvPathVersion: CSV_PATH_VERSION
+    reportFilesPathVersion: REPORT_FILES_PATH_VERSION,
+    pathToUserReportFiles
   })
 }
 
@@ -153,7 +127,7 @@ const _manageConfigs = (params = {}) => {
     pathToUserDocuments
   } = params
 
-  const pathToUserCsv = path.join(
+  const pathToUserReportFiles = path.join(
     pathToUserDocuments,
     'bitfinex/reports'
   )
@@ -161,18 +135,15 @@ const _manageConfigs = (params = {}) => {
   const configsKeeper = configsKeeperFactory(
     { pathToUserData },
     {
-      pathToUserCsv,
+      pathToUserReportFiles,
       schedulerRule,
       shownChangelogVer: '0.0.0',
       triggeredSyncAfterUpdatesVer: '0.0.0'
     }
   )
-  _resetCsvPath(
+  _resetReportFilesPath(
     configsKeeper,
-    {
-      pathToUserCsv,
-      isRelativeCsvPath: true
-    }
+    { pathToUserReportFiles }
   )
 }
 

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -41,6 +41,7 @@ const enforceMacOSAppLocation = require(
 const manageWorkerMessages = require(
   './manage-worker-messages'
 )
+const printToPDF = require('./print-to-pdf')
 
 const pathToLayouts = path.join(__dirname, 'layouts')
 const pathToLayoutAppInitErr = path
@@ -193,6 +194,8 @@ module.exports = async () => {
     await triggerElectronLoad(portsMap)
     await checkForUpdatesAndNotify()
     await manageChangelog()
+
+    printToPDF()
   } catch (err) {
     await createErrorWindow(pathToLayoutAppInitErr)
 

--- a/src/print-to-pdf/index.js
+++ b/src/print-to-pdf/index.js
@@ -15,7 +15,7 @@ const PROCESS_STATES = require(
 module.exports = () => {
   ipcs.serverIpc.on('message', async (mess) => {
     try {
-      if (mess?.state !== PROCESS_MESSAGES.CREATE_PDF) {
+      if (mess?.state !== PROCESS_MESSAGES.REQUEST_PDF_CREATION) {
         return
       }
 
@@ -64,16 +64,16 @@ module.exports = () => {
       })
 
       ipcs.serverIpc.send({
-        state: PROCESS_STATES.CREATED_PDF_BUFFER,
+        state: PROCESS_STATES.RESPONSE_PDF_CREATION,
         data: { buffer, uid }
       })
-    } catch (error) {
+    } catch (err) {
       ipcs.serverIpc.send({
-        state: PROCESS_STATES.ERROR_PDF_CREATION,
-        data: { error, uid: mess?.data?.uid ?? null }
+        state: PROCESS_STATES.RESPONSE_PDF_CREATION,
+        data: { err, uid: mess?.data?.uid ?? null }
       })
 
-      console.error(error)
+      console.error(err)
     }
   })
 }

--- a/src/print-to-pdf/index.js
+++ b/src/print-to-pdf/index.js
@@ -1,0 +1,79 @@
+'use strict'
+
+const { BrowserWindow } = require('electron')
+
+const ipcs = require('../ipcs')
+const wins = require('../windows')
+
+const PROCESS_MESSAGES = require(
+  '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
+)
+const PROCESS_STATES = require(
+  '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.states'
+)
+
+module.exports = () => {
+  ipcs.serverIpc.on('message', async (mess) => {
+    try {
+      if (mess?.state !== PROCESS_MESSAGES.CREATE_PDF) {
+        return
+      }
+
+      const {
+        template = 'No data',
+        format = 'portrait',
+        orientation = 'Letter',
+        uid = null
+      } = mess?.data ?? {}
+
+      const win = new BrowserWindow({
+        show: false,
+        parent: wins.mainWindow,
+        webPreferences: {
+          nodeIntegration: true
+        }
+      })
+      win.loadURL(`data:text/html;charset=utf-8,${encodeURIComponent(template)}`)
+
+      await new Promise((resolve, reject) => {
+        win.webContents.on('did-finish-load', resolve)
+        win.webContents.on('did-fail-load', (e, code, err) => {
+          reject(err)
+        })
+      })
+      const buffer = await win.webContents.printToPDF({
+        landscape: format !== 'portrait',
+        pageSize: orientation,
+        margins: {
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0
+        },
+        displayHeaderFooter: true,
+        footerTemplate: `\
+<span style="
+    position: absolute;
+    right: 10px;
+    bottom: 10px;
+    font-weight: 400;
+    font-size: 8px;
+  ">
+  Page <span class=pageNumber></span> from <span class=totalPages></span>
+</span>`
+      })
+
+      ipcs.serverIpc.send({
+        state: PROCESS_STATES.CREATED_PDF_BUFFER,
+        data: { buffer, uid }
+      })
+    } catch (error) {
+      ipcs.serverIpc.send({
+        state: PROCESS_STATES.ERROR_PDF_CREATION,
+        data: { error, uid: mess?.data?.uid ?? null }
+      })
+
+      console.error(error)
+    }
+  })
+}

--- a/src/run-server.js
+++ b/src/run-server.js
@@ -28,8 +28,8 @@ module.exports = ({
   const env = {
     ...process.env,
     PATH_TO_USER_DATA: pathToUserData,
-    PATH_TO_USER_CSV: mainConfsKeeper
-      .getConfigByName('pathToUserCsv'),
+    PATH_TO_USER_REPORT_FILES: mainConfsKeeper
+      .getConfigByName('pathToUserReportFiles'),
     SCHEDULER_RULE: mainConfsKeeper
       .getConfigByName('schedulerRule'),
     SECRET_KEY: secretKey,


### PR DESCRIPTION
This PR adds support for `PDF` reports

---

Basic changes:
- the minimum required refactoring in order to be able to add support for pdf to the current csv generation flow
- adds logic to be able to generate PDF under `Electronjs` using the native api of `Chromium` https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions

---

How PDF generation works

For PDF generation uses browser emulation with printing HTML to PDF format:
- under Electronjs uses the internal api which used via the IPC (between framework child process and main electronjs process) with the newest browser emulation `Chromium` https://www.electronjs.org/docs/latest/api/web-contents#contentsprinttopdfoptions

Feature has the following flow:
- `PUG` templates which provide flexibility with inheritance and mixins
- render `PUG` template to `HTML` + inline CSS + inline fonts in base64 to have everything in one HTML string
- as IPC sends data between the main and child processes synchronously it works following:
  - in the framework writes HTML into temporary file asynchronously
  - send message via IPC with HTML file path to electron handler
  - under electron, reads HTML file (if ok removes temp file) and prints to PDF asynchronously
  - then writes PDF into temporary file asynchronously
  - send an answer message via IPC with PDF file path to the framework handler
  - if the framework can read the file it removes the temp file

---

**Depends** on these PRs:
- https://github.com/bitfinexcom/bfx-report/pull/347
- https://github.com/bitfinexcom/bfx-reports-framework/pull/352
