### PR TITLE
Optimize GitHub workflow for release build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
+REPO_OWNER=bitfinexcom
 REPO_BRANCH=master
 IS_BFX_API_STAGING=0
 IS_DEV_ENV=0

--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -36,11 +36,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Set repo owner
-      run: |
-        sed -i -e \
-          "s/owner: '.*'/owner: '${{ github.repository_owner }}'/g" \
-          "./electron-builder-config.js"
     - if: github.event.inputs.version != ''
       name: Set release version
       run: |
@@ -73,6 +68,7 @@ jobs:
       continue-on-error: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO_OWNER: ${{ github.repository_owner }}
       with:
         timeout_minutes: 20
         retry_wait_seconds: 10
@@ -110,11 +106,6 @@ jobs:
       run: |
         brew install gnu-sed
         echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
-    - name: Set repo owner
-      run: |
-        sed -i -e \
-          "s/owner: '.*'/owner: '${{ github.repository_owner }}'/g" \
-          "./electron-builder-config.js"
     - if: github.event.inputs.version != ''
       name: Set release version
       run: |
@@ -158,6 +149,7 @@ jobs:
         CSC_LINK: ${{ secrets.BFX_APPLE_BUILD_CERTIFICATE_B64 }}
         CSC_KEY_PASSWORD: ${{ secrets.BFX_APPLE_BUILD_CERTIFICATE_PASSWORD }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        REPO_OWNER: ${{ github.repository_owner }}
         ELECTRON_CACHE: ${{ runner.temp }}/.cache/electron
       with:
         timeout_minutes: 40

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -16,6 +16,7 @@ jobs:
   e2e-web-page-report:
     name: E2E Web Page Report
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: dorny/test-reporter@v1
       id: linux-e2e-test-results

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -16,6 +16,7 @@ jobs:
   web-page-report:
     name: Web Page Report
     runs-on: ubuntu-22.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: dorny/test-reporter@v1
       id: test-results

--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -14,6 +14,7 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.mac-builder
+++ b/Dockerfile.mac-builder
@@ -14,6 +14,7 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -8,6 +8,7 @@ ENV IS_DEV_ENV=${IS_DEV_ENV:-0}
 COPY ./scripts/helpers/install-nodejs.sh ./scripts/helpers/install-nodejs.sh
 
 RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION}
+RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -17,6 +17,7 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
+RUN chown root:root .
 
 COPY . .
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       IS_PUBLISHED: ${IS_PUBLISHED:-0}
       GH_TOKEN: ${GH_TOKEN:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      REPO_OWNER: ${REPO_OWNER:-}
       EP_GH_IGNORE_TIME: ${EP_GH_IGNORE_TIME:-true}
       CURRENT_UID: ${CURRENT_UID:-"1000:1000"}
     volumes:
@@ -52,6 +53,7 @@ services:
       IS_PUBLISHED: ${IS_PUBLISHED:-0}
       GH_TOKEN: ${GH_TOKEN:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      REPO_OWNER: ${REPO_OWNER:-}
       EP_GH_IGNORE_TIME: ${EP_GH_IGNORE_TIME:-true}
       CURRENT_UID: ${CURRENT_UID:-"1000:1000"}
     volumes:
@@ -76,6 +78,7 @@ services:
       IS_PUBLISHED: ${IS_PUBLISHED:-0}
       GH_TOKEN: ${GH_TOKEN:-}
       GITHUB_TOKEN: ${GITHUB_TOKEN:-}
+      REPO_OWNER: ${REPO_OWNER:-}
       EP_GH_IGNORE_TIME: ${EP_GH_IGNORE_TIME:-true}
       CURRENT_UID: ${CURRENT_UID:-"1000:1000"}
     volumes:

--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -12,6 +12,59 @@ const parseEnvValToBool = require(
   './src/helpers/parse-env-val-to-bool'
 )
 
+const electronEnvVars = {
+  REPO_OWNER: 'bitfinexcom'
+}
+let electronEnvVarsFromFile = {}
+
+const electronEnvFilePath = path.join(
+  __dirname, 'electronEnv.json'
+)
+const electronEnvExampleFilePath = path.join(
+  __dirname, 'electronEnv.json.example'
+)
+
+let hasElectronEnv = false
+let hasNewElectronEnv = false
+
+try {
+  electronEnvVarsFromFile = require(electronEnvFilePath)
+  Object.assign(electronEnvVars, electronEnvVarsFromFile)
+  hasElectronEnv = true
+} catch (err) {}
+
+if (!hasElectronEnv) {
+  try {
+    electronEnvVarsFromFile = JSON.parse(
+      fs.readFileSync(electronEnvExampleFilePath, 'utf8')
+    )
+    Object.assign(electronEnvVars, electronEnvVarsFromFile)
+    fs.writeFileSync(
+      electronEnvFilePath,
+      JSON.stringify(electronEnvVars, null, 2),
+      'utf8'
+    )
+    hasElectronEnv = true
+  } catch (err) {}
+}
+
+if (process.env.REPO_OWNER) {
+  electronEnvVars.REPO_OWNER = process.env.REPO_OWNER
+}
+if (electronEnvVars.REPO_OWNER !== electronEnvVarsFromFile.REPO_OWNER) {
+  hasNewElectronEnv = true
+}
+
+if (hasNewElectronEnv) {
+  try {
+    fs.writeFileSync(
+      electronEnvFilePath,
+      JSON.stringify(electronEnvVars, null, 2),
+      'utf8'
+    )
+  } catch (err) {}
+}
+
 let version
 let zippedAppImageArtifactPath
 let zippedMacArtifactPath
@@ -88,7 +141,7 @@ module.exports = {
   publish: {
     provider: 'github',
     repo: 'bfx-report-electron',
-    owner: 'bitfinexcom',
+    owner: electronEnvVars.REPO_OWNER,
     vPrefixedTagName: true,
     channel: 'latest',
 

--- a/electronEnv.json.example
+++ b/electronEnv.json.example
@@ -1,4 +1,5 @@
 {
   "NODE_ENV": "production",
-  "IS_AUTO_UPDATE_DISABLED": false
+  "IS_AUTO_UPDATE_DISABLED": false,
+  "REPO_OWNER": "bitfinexcom"
 }


### PR DESCRIPTION
This PR optimizes GitHub Actions Workflow for release build

---

Basic changes:
- Prevents `electron-builder` config modifying when setting repo owner in GH Actions Workflow, adds ability to set repo owner from env var into electron-builder config. It's more secure and flexible for beta releases as well
- Skips GH Actions Workflow for tests report if the test runner is canceled
- Launchs GH Actions Workflow for E2E tests when the build is successful
- Fixes random failed to install npm package from git in Docker. Related to this issue: https://github.com/npm/cli/issues/624
