### PR TITLE
Update actions to use Nodejs v20

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -193,7 +193,7 @@ jobs:
     - name: Unzip Linux Unpacked build
       run: unzip dist/linux-unpacked.zip
     - name: Run tests
-      uses: coactions/setup-xvfb@v1.0.1
+      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report
@@ -225,7 +225,7 @@ jobs:
     - name: Unzip Win Unpacked build
       run: 7z -y x dist/win-unpacked.zip
     - name: Run tests
-      uses: coactions/setup-xvfb@v1.0.1
+      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report
@@ -259,7 +259,7 @@ jobs:
     - name: Unzip Mac Unpacked build
       run: unzip dist/mac.zip
     - name: Run tests
-      uses: coactions/setup-xvfb@v1.0.1
+      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report

--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -52,7 +52,7 @@ jobs:
         echo "IS_BFX_API_STAGING=1" >> $GITHUB_ENV
     - name: Cache Electron binaries
       id: electron-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: electron-cache-v1
       with:
@@ -64,7 +64,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
     - name: Build release
       id: release-builder
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       continue-on-error: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -78,14 +78,14 @@ jobs:
     - name: Zip Linux Unpacked build
       run: zip -r dist/linux-unpacked.zip dist/linux-unpacked
     - name: Upload Linux Unpacked build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-unpacked
         path: dist/linux-unpacked.zip
     - name: Zip Win Unpacked build
       run: zip -r dist/win-unpacked.zip dist/win-unpacked
     - name: Upload Win Unpacked build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: win-unpacked
         path: dist/win-unpacked.zip
@@ -124,12 +124,12 @@ jobs:
       name: Use BFX API Staging for queries
       run: |
         echo "IS_BFX_API_STAGING=1" >> $GITHUB_ENV
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Cache Electron binaries
       id: electron-cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       env:
         cache-name: electron-cache-v1
       with:
@@ -140,7 +140,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
     - name: Build release
       id: release-builder
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@v3
       continue-on-error: false
       env:
         APPLE_TEAM_ID: ${{ secrets.BFX_APPLE_TEAM_ID }}
@@ -167,7 +167,7 @@ jobs:
     - name: Zip Mac Unpacked build
       run: zip -r dist/mac.zip dist/mac
     - name: Upload Mac Unpacked build
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mac-unpacked
         path: dist/mac.zip
@@ -180,13 +180,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Install main dev deps
       run: npm i --development --no-audit --progress=false --force
     - name: Download Linux Unpacked build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: linux-unpacked
         path: dist
@@ -199,7 +199,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Linux E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-e2e-test-results
         path: e2e-test-report.xml
@@ -212,13 +212,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Install main dev deps
       run: npm i --development --no-audit --progress=false --force
     - name: Download Linux Unpacked build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: win-unpacked
         path: dist
@@ -231,7 +231,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Win E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: win-e2e-test-results
         path: e2e-test-report.xml
@@ -246,13 +246,13 @@ jobs:
       uses: actions/checkout@v4
     - name: Prepare Mac runner
       uses: ./.github/actions/prepare-mac-runner
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Install main dev deps
       run: npm i --development --no-audit --progress=false --force
     - name: Download Mac Unpacked build
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: mac-unpacked
         path: dist
@@ -265,7 +265,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Mac E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mac-e2e-test-results
         path: e2e-test-report.xml

--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -199,7 +199,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Linux E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: linux-e2e-test-results
         path: e2e-test-report.xml
@@ -231,7 +231,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Win E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: win-e2e-test-results
         path: e2e-test-report.xml
@@ -265,7 +265,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Mac E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: mac-e2e-test-results
         path: e2e-test-report.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,14 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 18.17.1
     - name: Setup configs and install deps
       run: ./scripts/setup.sh -u
     - name: Run tests
       run: npm test -- -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test-results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: ./scripts/setup.sh -u
     - name: Run tests
       run: npm test -- -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       if: success() || failure()
       with:
         name: test-results

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -152,12 +152,12 @@ fi
 if [ $isAutoUpdateDisabled == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Auto-update is turned off!${COLOR_NORMAL}"
 
-  sed -i -e \
-    "s/\"IS_AUTO_UPDATE_DISABLED\": .*/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
+  sed -i -E -e \
+    "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
     "$ROOT/$ELECTRON_ENV_FILE_NAME"
 else
-  sed -i -e \
-    "s/\"IS_AUTO_UPDATE_DISABLED\": .*/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
+  sed -i -E -e \
+    "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
     "$ROOT/$ELECTRON_ENV_FILE_NAME"
 fi
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -94,12 +94,12 @@ fi
 if [ $isAutoUpdateDisabled == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Auto-update is turned off!${COLOR_NORMAL}"
 
-  sed -i -e \
-    "s/\"IS_AUTO_UPDATE_DISABLED\": .*/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
+  sed -i -E -e \
+    "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
     "$ROOT/$ELECTRON_ENV_FILE_NAME"
 else
-  sed -i -e \
-    "s/\"IS_AUTO_UPDATE_DISABLED\": .*/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
+  sed -i -E -e \
+    "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
     "$ROOT/$ELECTRON_ENV_FILE_NAME"
 fi
 


### PR DESCRIPTION
This PR updates GH Actions to use Nodejs `v20`

---

Context: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Our current warnings: https://github.com/bitfinexcom/bfx-report-electron/actions/runs/7913595670

![Screenshot from 2024-02-22 14-56-35](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/6b2527a2-6d91-4b86-9a8e-f13953d77641)

---

Basic changes:
- Update gh actions to resolve deprecation warnings
- Point `coactions/setup-xvfb` gh action to exact commit to have required nodejs ver under hood: resolved here https://github.com/coactions/setup-xvfb/pull/23
- Fix disabling auto-update when build release. Minore improvement for `beta` releases

---

TODO:
- GH Action `dorny/test-reporter` does not still support `actions/upload-artifact@v4` required for Nodejs 20 migration. And to upload `test reports` needs to use `v3` with Nodejs v16 which will show one related warning https://github.com/dorny/test-reporter/issues/363
So here we are waiting for `dorny/test-reporter` changes to have the last resolved
No breaking changes here and can be merged freely

---

Everything has been tested on own fork:
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/8017162965
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/8017417802
