### PR TITLE
Improve print pdf under electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "app-builder-bin": "4.2.0",
     "cross-env": "7.0.3",
     "dotenv": "16.3.1",
-    "electron": "27.2.0",
+    "electron": "27.3.5",
     "electron-builder": "24.10.0",
     "mocha": "10.2.0",
     "standard": "17.1.0",

--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -216,7 +216,9 @@ const initLogger = () => {
       if (
         /Cannot download differentially/gi.test(error) ||
         /ERR_CONNECTION_REFUSED/gi.test(error) ||
-        /objects\.githubusercontent\.com/gi.test(error)
+        /objects\.githubusercontent\.com/gi.test(error) ||
+        /Error: ERR_FAILED \(-2\) loading 'file:.*\.html'/gi.test(error) ||
+        /Failed to generate PDF/gi.test(error)
       ) {
         return message
       }

--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -169,6 +169,7 @@ const manageNewGithubIssue = async (params) => {
 }
 
 const initLogger = () => {
+  log.transports.ipc.level = false
   log.transports.console.level = isDevEnv
     ? 'debug'
     : 'warn'


### PR DESCRIPTION
This PR improves print pdf under electron

---

Basic changes:
- Turn off ipc log transport between render and main process as unused, it prevents ipc transport error from `electron-log` lib like:
```console
Error sending from webFrameMain:  Error: Render frame was disposed before WebFrameMain could be accessed
    at WebFrameMain.send (node:electron/js2c/browser_init:2:93682)
    at WebContents.send (node:electron/js2c/browser_init:2:79161)
    at /home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/electronApi.js:205:23
    at Array.forEach (<anonymous>)
    at sendIpcToRenderer (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/electronApi.js:203:42)
    at Object.sendIpc (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/electronApi.js:185:5)
    at transport (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/transports/ipc.js:40:17)
    at runTransport (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/log.js:44:5)
    at runTransports (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/log.js:27:7)
    at log (/home/vladimir/projects/bitfinex/bfx-report-electron/node_modules/electron-log/src/log.js:21:3)
```
- Suppress err modal window if pdf gen failed. The idea here is to inform the user if something goes wrong using WS event for better UX instead of showing a modal window error as it is annoying in most cases
- Improve pdf generation performance for big html templates, uses `loadFile` method of electron api instead of `base64` encoding
- Bump up electron minor version to have the last fixes

---

**Depends** on these PRs:
- https://github.com/bitfinexcom/bfx-report/pull/354
- https://github.com/bitfinexcom/bfx-reports-framework/pull/359
