### PR TITLE
Update gh actions to use nodejs v20

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -214,7 +214,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Linux E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-e2e-test-results
         path: e2e-test-report.xml
@@ -246,7 +246,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Win E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: win-e2e-test-results
         path: e2e-test-report.xml
@@ -280,7 +280,7 @@ jobs:
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Mac E2E test results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mac-e2e-test-results
         path: e2e-test-report.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run: ./scripts/setup.sh -u
     - name: Run tests
       run: npm test -- -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
         name: test-results

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -18,26 +18,38 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Download Linux E2E test results
+      uses: actions/download-artifact@v4
+      with:
+        name: linux-e2e-test-results
+        path: linux-e2e-test-results
+    - uses: dorny/test-reporter@v1.8.0
       id: linux-e2e-test-results
       with:
-        artifact: linux-e2e-test-results
         name: Linux E2E Tests
-        path: e2e-test-report.xml
+        path: linux-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
-    - uses: dorny/test-reporter@v1
+    - name: Download Win E2E test results
+      uses: actions/download-artifact@v4
+      with:
+        name: win-e2e-test-results
+        path: win-e2e-test-results
+    - uses: dorny/test-reporter@v1.8.0
       id: win-e2e-test-results
       with:
-        artifact: win-e2e-test-results
         name: Win E2E Tests
-        path: e2e-test-report.xml
+        path: win-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
-    - uses: dorny/test-reporter@v1
+    - name: Download Mac E2E test results
+      uses: actions/download-artifact@v4
+      with:
+        name: mac-e2e-test-results
+        path: mac-e2e-test-results
+    - uses: dorny/test-reporter@v1.8.0
       id: mac-e2e-test-results
       with:
-        artifact: mac-e2e-test-results
         name: Mac E2E Tests
-        path: e2e-test-report.xml
+        path: mac-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
     - name: E2E Test Report Summary
       run: |

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -31,6 +31,9 @@ jobs:
         name: Linux E2E Tests
         path: linux-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
+        # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
+        max-annotations: 0
     - name: Download Win E2E test results
       uses: actions/download-artifact@v4
       with:
@@ -44,6 +47,7 @@ jobs:
         name: Win E2E Tests
         path: win-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        max-annotations: 0
     - name: Download Mac E2E test results
       uses: actions/download-artifact@v4
       with:
@@ -57,6 +61,7 @@ jobs:
         name: Mac E2E Tests
         path: mac-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        max-annotations: 0
     - name: E2E Test Report Summary
       run: |
         echo "### E2E Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Download Linux E2E test results
       uses: actions/download-artifact@v4
       with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         name: linux-e2e-test-results
         path: linux-e2e-test-results
     - uses: dorny/test-reporter@v1.8.0
@@ -32,6 +34,8 @@ jobs:
     - name: Download Win E2E test results
       uses: actions/download-artifact@v4
       with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         name: win-e2e-test-results
         path: win-e2e-test-results
     - uses: dorny/test-reporter@v1.8.0
@@ -43,6 +47,8 @@ jobs:
     - name: Download Mac E2E test results
       uses: actions/download-artifact@v4
       with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         name: mac-e2e-test-results
         path: mac-e2e-test-results
     - uses: dorny/test-reporter@v1.8.0

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -31,6 +31,9 @@ jobs:
         name: Mocha Tests
         path: test-results/test-report.json
         reporter: mocha-json
+        # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
+        # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
+        max-annotations: 0
     - name: Test Report Summary
       run: |
         echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -18,12 +18,16 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-    - uses: dorny/test-reporter@v1
+    - name: Download test results
+      uses: actions/download-artifact@v4
+      with:
+        name: test-results
+        path: test-results
+    - uses: dorny/test-reporter@v1.8.0
       id: test-results
       with:
-        artifact: test-results
         name: Mocha Tests
-        path: test-report.json
+        path: test-results/test-report.json
         reporter: mocha-json
     - name: Test Report Summary
       run: |

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -21,6 +21,8 @@ jobs:
     - name: Download test results
       uses: actions/download-artifact@v4
       with:
+        run-id: ${{ github.event.workflow_run.id }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         name: test-results
         path: test-results
     - uses: dorny/test-reporter@v1.8.0


### PR DESCRIPTION
This PR adds the last part of the previous https://github.com/bitfinexcom/bfx-report-electron/pull/323 updates GH Actions to use Nodejs v20

---

Context: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
Our current warnings: https://github.com/bitfinexcom/bfx-report-electron/actions/runs/8169998113

---

Solution:
- as `dorny/test-reporter` GH Action is stuck with the update to support actions/upload-artifact@v4
- turns off downloading test results managed `dorny/test-reporter` with removing `artifact` options
- adds additional downloading step before `dorny/test-reporter` using `actions/download-artifact@v4` actions
- and after all, we can use `actions/upload-artifact@v4` everywhere

---

**Notes:**
- after opening PR against `master` the unit tests will be triggered, but `Test Report` will fail because the GH Actions don't want to take the last incoming changes of the corresponding workflow file and uses already existing changes in the master branch that are incompatible. And after merging in the next release iteration, everything should work as expected
- the first release launch
![Screenshot from 2024-03-13 08-25-46](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/f4a107eb-121f-46cd-892d-d38333edb0ac)
- the next release launch
![Screenshot from 2024-03-13 08-26-44](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/d0dd11c7-b1bb-45da-9d0a-3d103b88491d)
