### PR TITLE
Add ability to upload dist release if repo owner is customized

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -83,7 +83,12 @@ jobs:
         retry_wait_seconds: 10
         max_attempts: 3
         retry_on: any
-        command: ./scripts/launch.sh -lwp
+        command: |
+          if [[ "${REPO_OWNER}" != "${{ github.repository_owner }}" ]]; then
+            ./scripts/launch.sh -lw
+          else
+            ./scripts/launch.sh -lwp
+          fi
     - name: Zip Linux Unpacked build
       run: zip -r dist/linux-unpacked.zip dist/linux-unpacked
     - name: Upload Linux Unpacked build
@@ -98,6 +103,24 @@ jobs:
       with:
         name: win-unpacked
         path: dist/win-unpacked.zip
+    - if: env.REPO_OWNER != github.repository_owner
+      name: Upload Linux Dist Release
+      uses: actions/upload-artifact@v4
+      with:
+        name: linux-dist-release
+        path: |
+          dist/*-linux.AppImage
+          dist/*-linux.AppImage.zip
+          dist/latest-linux.yml
+    - if: env.REPO_OWNER != github.repository_owner
+      name: Upload Win Dist Release
+      uses: actions/upload-artifact@v4
+      with:
+        name: win-dist-release
+        path: |
+          dist/*-win.exe
+          dist/*-win.exe.blockmap
+          dist/latest.yml
     - name: Prepare cache folders
       run: |
         sudo chown -R $(id -u):$(id -g) ~/.cache/electron
@@ -178,7 +201,11 @@ jobs:
           if [[ -z "${APPLE_APP_SPECIFIC_PASSWORD}" || "${NOTARIZE:-}" != "1" ]]; then unset APPLE_APP_SPECIFIC_PASSWORD; fi
           if [[ -z "${CSC_LINK}" || "${NOTARIZE:-}" != "1" ]]; then unset CSC_LINK; fi
           if [[ -z "${CSC_KEY_PASSWORD}" || "${NOTARIZE:-}" != "1" ]]; then unset CSC_KEY_PASSWORD; fi
-          ./scripts/build-release.sh -mp
+          if [[ "${REPO_OWNER}" != "${{ github.repository_owner }}" ]]; then
+            ./scripts/build-release.sh -m
+          else
+            ./scripts/build-release.sh -mp
+          fi
     - name: Zip Mac Unpacked build
       run: zip -r dist/mac.zip dist/mac
     - name: Upload Mac Unpacked build
@@ -186,6 +213,15 @@ jobs:
       with:
         name: mac-unpacked
         path: dist/mac.zip
+    - if: env.REPO_OWNER != github.repository_owner
+      name: Upload Mac Dist Release
+      uses: actions/upload-artifact@v4
+      with:
+        name: mac-dist-release
+        path: |
+          dist/*-mac.zip
+          dist/*-mac.zip.blockmap
+          dist/latest-mac.yml
 
   linux-e2e-test-runner:
     name: Linux E2E Test Runner

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -226,6 +226,8 @@ publishOption=""
 if [ $isPublished == 1 ]; then
   # Available: 'onTag', 'onTagOrDraft', 'always', 'never'
   publishOption="--publish always"
+else
+  publishOption="--publish never"
 fi
 
 rm -rf "$DIST_FOLDER/"*"$targetPlatform"*


### PR DESCRIPTION
This PR adds ability to upload a dist release if the repo owner is customized

---

The idea is the following:
- have the ability to set custom repo owner for auto-update
- it's useful for `beta` and `main` releases made against the `forked` repo
- as the `electron-builder` does not support separate customization of repo owner for publishing and auto-update
- if the custom repo owner is set
- and its set value is different from the current actual repo owner
- turn off the publishing feature of the `electron-builder` functionality
- and then use `actions/upload-artifact@v4` after being built to upload binaries to the `Artifacts` section of the `Build release` workflow like shown here https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/8276698230

![Screenshot from 2024-03-14 09-33-40](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/40041b2b-b7d3-4fce-812b-0d9ffb8a07e7)

![Screenshot from 2024-03-14 09-34-34](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/c0720f8a-e47f-430f-87cf-ffafa2fd290c)

![Screenshot from 2024-03-14 09-32-15](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/847d11d1-4f9d-4ff5-b88b-5e5154c16bc0)

![Screenshot from 2024-03-13 14-48-04](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/008cdbe4-f0ea-4c0c-830d-129117bd305c)

![Screenshot from 2024-03-13 11-08-01](https://github.com/bitfinexcom/bfx-report-electron/assets/16489235/14e87daa-0bb3-47d7-8955-00de02c38fb1)


