### PR TITLE
Add dmg mac dist release uploading

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -221,6 +221,8 @@ jobs:
         path: |
           dist/*-mac.zip
           dist/*-mac.zip.blockmap
+          dist/*-mac.dmg
+          dist/*-mac.dmg.blockmap
           dist/latest-mac.yml
 
   linux-e2e-test-runner:


### PR DESCRIPTION
Add `dmg` mac dist release uploading in case of manual build on a fork

---

**Related** to this issue:
- https://github.com/bitfinexcom/bfx-report-electron/issues/352
