### PR TITLE
Release version 4.23.0

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -221,6 +221,8 @@ jobs:
         path: |
           dist/*-mac.zip
           dist/*-mac.zip.blockmap
+          dist/*-mac.dmg
+          dist/*-mac.dmg.blockmap
           dist/latest-mac.yml
 
   linux-e2e-test-runner:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.21.0] - 2024-03-20
+
+### Added
+
+- Added ability to handle `PDFBufferUnderElectronCreationError` error to use WebSockets to inform users for better UX. PRs: [bfx-report#354](https://github.com/bitfinexcom/bfx-report/pull/354), [bfx-reports-framework#359](https://github.com/bitfinexcom/bfx-reports-framework/pull/359)
+- Implemented support for `emitReportFileGenerationFailedToOne` ws events on UI side to inform users about report generation failing. PR: [bfx-report-ui#787](https://github.com/bitfinexcom/bfx-report-ui/pull/787)
+- Added missing translations for PDF reports. PRs: [bfx-report#356](https://github.com/bitfinexcom/bfx-report/pull/356), [bfx-reports-framework#362](https://github.com/bitfinexcom/bfx-reports-framework/pull/362)
+- Added DB migration for `publicCollsConf` table name with Cyrillic `c`. PR: [bfx-reports-framework#360](https://github.com/bitfinexcom/bfx-reports-framework/pull/360)
+- Added migration for public colls conf endpoint name with Cyrillic `c`. PR: [bfx-report-ui#788](https://github.com/bitfinexcom/bfx-report-ui/pull/788)
+- Added ability to upload dist release if repo owner is customized using manual build run. PR: [bfx-report-electron#347](https://github.com/bitfinexcom/bfx-report-electron/pull/347)
+
+### Changed
+
+- Updated `GH Actions` to use Nodejs `v20` to prevent breaking changes in workflow. PRs: [bfx-report#355](https://github.com/bitfinexcom/bfx-report/pull/355), [bfx-reports-framework#361](https://github.com/bitfinexcom/bfx-reports-framework/pull/361), [bfx-report-electron#344](https://github.com/bitfinexcom/bfx-report-electron/pull/344), [bfx-facs-db-better-sqlite#9](https://github.com/bitfinexcom/bfx-facs-db-better-sqlite/pull/9)
+- Migrated from the `deprecated` reports generation methods usage to the actual ones according to the latest backend changes. PR: [bfx-report-ui#784](https://github.com/bitfinexcom/bfx-report-ui/pull/784)
+- Allowed all pairs removal at the `Market History / Spot` section according to the latest UX improvement proposals: We should allow the user to remove the current pair and display an empty table that says `No history to display`. PR: [bfx-report-ui#786](https://github.com/bitfinexcom/bfx-report-ui/pull/786)
+- Improved print PDF under Electronjs. Turned off ipc log transport between render and main process as unused, it prevents ipc transport error from `electron-log` lib. Suppressed error modal window if pdf gen failed: the idea here is to inform the user if something goes wrong using WS event for better UX instead of showing a modal window error as it is annoying in most cases. Improved pdf generation performance for big html templates, uses `loadFile` method of electron api instead of `base64` encoding. Bumped up Electronjs minor version to have the last fixes. PR: [bfx-report-electron#342](https://github.com/bitfinexcom/bfx-report-electron/pull/342)
+
+### Fixed
+
+- Prevented duplication possibility for items in the selectors of the UI. PR: [bfx-report-ui#785](https://github.com/bitfinexcom/bfx-report-ui/pull/785)
+
 ## [4.20.0] - 2024-03-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.23.0] - 2024-04-17
+
+### Added
+
+- Implemented `isStagingBfxApi` flag handling and shows `Staging` prefix for the corresponding keys stored in the DB to improve the manual testing process convenience. PR: [bfx-report-ui#800](https://github.com/bitfinexcom/bfx-report-ui/pull/800)
+- Implemented the possibility of manually adjusting columns width and persisting these between sessions. Added the ability to set the auto-calculated dynamic defaults via the context menu. Improved charts responsiveness. PR: [bfx-report-ui#805](https://github.com/bitfinexcom/bfx-report-ui/pull/805)
+
+### Changed
+
+- Updated `GH Actions` `setup-node` to `v4` to prevent breaking changes in workflow. PRs: [bfx-facs-db-better-sqlite#10](https://github.com/bitfinexcom/bfx-facs-db-better-sqlite/pull/10), [bfx-report#365](https://github.com/bitfinexcom/bfx-report/pull/365), [bfx-reports-framework#369](https://github.com/bitfinexcom/bfx-reports-framework/pull/369)
+- Increased the inner `limit` for the BFX API `trades/{symbol}/hist` endpoint. It's useful for the `Transaction Tax Report` in case of currency conversion to USD to reduce the amount of calls and help users to go through `Rate Limit`. PR: [bfx-report#363](https://github.com/bitfinexcom/bfx-report/pull/363)
+- Speeded up `auth` in case token expiration to prevent redundant awaiting. PR: [bfx-report#364](https://github.com/bitfinexcom/bfx-report/pull/364)
+- Reverted tables responsiveness in the UI. PR: [bfx-report-ui#801](https://github.com/bitfinexcom/bfx-report-ui/pull/801)
+- Reverted the option to revert table width as an always dynamic component. PR: [bfx-report-ui#802](https://github.com/bitfinexcom/bfx-report-ui/pull/802)
+- Extended and improved click tracking all across the `Reports`. PR: [bfx-report-ui#803](https://github.com/bitfinexcom/bfx-report-ui/pull/803)
+- Enhanced `Reports` navigation menu representation. PR: [bfx-report-ui#804](https://github.com/bitfinexcom/bfx-report-ui/pull/804)
+
+### Fixed
+
+- Fixed `action` prop passing for the `WS` in case an error. PR: [bfx-report-express#38](https://github.com/bitfinexcom/bfx-report-express/pull/38)
+
 ## [4.22.0] - 2024-04-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.22.0] - 2024-04-03
+
+### Added
+
+- Implemented dynamic width support for the `Reports` tables according to: the tables should stretch and fill horizontally (width 100%). PR: [bfx-report-ui#794](https://github.com/bitfinexcom/bfx-report-ui/pull/794)
+- Added `DMG` Mac dist release uploading in case of manual build on a fork. Related to this issue: [bfx-report-electron#352](https://github.com/bitfinexcom/bfx-report-electron/issues/352). PR: [bfx-report-electron#357](https://github.com/bitfinexcom/bfx-report-electron/pull/357)
+- Added handling unexpected BFX API errors, added `3` retries with a timeout `10sec` if catches any unexpected errors during report generation or DB sync in framework mode. Related to these issues: [bfx-report-electron#354](https://github.com/bitfinexcom/bfx-report-electron/issues/354), [bfx-report-electron#355](https://github.com/bitfinexcom/bfx-report-electron/issues/355). PR: [bfx-report#359](https://github.com/bitfinexcom/bfx-report/pull/359)
+- Added additional processing for JSON DB file of the `LokiJS`. In some rare cases due to an unexpected termination of the app process, the JSON file used for LokiJS can not be finished recording correctly. Related to this issue: [bfx-report-electron#353](https://github.com/bitfinexcom/bfx-report-electron/issues/353). PR: [bfx-reports-framework#365](https://github.com/bitfinexcom/bfx-reports-framework/pull/365)
+
+### Changed
+
+- Improved export type selection, added Export Format selector (similar to Date Format) with 2 options: 1-export as CSV (should be selected by default), 2-export as PDF. PR: [bfx-report-ui#795](https://github.com/bitfinexcom/bfx-report-ui/pull/795)
+- Extended error logs for sync proc, the idea is to add `serializedError` field to the error object with a serialized error string that contains composed error metadata for easier debugging of the user's error reports. This field will be used for logging in case catching error occurs during sync in the framework mode. PRs: [bfx-report#360](https://github.com/bitfinexcom/bfx-report/pull/360), [bfx-reports-framework#366](https://github.com/bitfinexcom/bfx-reports-framework/pull/366)
+
+### Security
+
+- Resolved `dependabot` dependency updates, bumped `follow-redirects` from `1.15.5` to `1.15.6`, `webpack-dev-middleware` from `5.3.3` to `5.3.4`, `express` from `4.18.2` to `4.19.2`. PRs: [bfx-report-ui#792](https://github.com/bitfinexcom/bfx-report-ui/pull/792), [bfx-report-ui#797](https://github.com/bitfinexcom/bfx-report-ui/pull/797)
+
 ## [4.21.0] - 2024-03-20
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.20.0",
+  "version": "4.21.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.22.0",
+  "version": "4.23.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",


### PR DESCRIPTION
## [4.23.0] - 2024-04-17

### Added

- Implemented `isStagingBfxApi` flag handling and shows `Staging` prefix for the corresponding keys stored in the DB to improve the manual testing process convenience. PR: [bfx-report-ui#800](https://github.com/bitfinexcom/bfx-report-ui/pull/800)
- Implemented the possibility of manually adjusting columns width and persisting these between sessions. Added the ability to set the auto-calculated dynamic defaults via the context menu. Improved charts responsiveness. PR: [bfx-report-ui#805](https://github.com/bitfinexcom/bfx-report-ui/pull/805)

### Changed

- Updated `GH Actions` `setup-node` to `v4` to prevent breaking changes in workflow. PRs: [bfx-facs-db-better-sqlite#10](https://github.com/bitfinexcom/bfx-facs-db-better-sqlite/pull/10), [bfx-report#365](https://github.com/bitfinexcom/bfx-report/pull/365), [bfx-reports-framework#369](https://github.com/bitfinexcom/bfx-reports-framework/pull/369)
- Increased the inner `limit` for the BFX API `trades/{symbol}/hist` endpoint. It's useful for the `Transaction Tax Report` in case of currency conversion to USD to reduce the amount of calls and help users to go through `Rate Limit`. PR: [bfx-report#363](https://github.com/bitfinexcom/bfx-report/pull/363)
- Speeded up `auth` in case token expiration to prevent redundant awaiting. PR: [bfx-report#364](https://github.com/bitfinexcom/bfx-report/pull/364)
- Reverted tables responsiveness in the UI. PR: [bfx-report-ui#801](https://github.com/bitfinexcom/bfx-report-ui/pull/801)
- Reverted the option to revert table width as an always dynamic component. PR: [bfx-report-ui#802](https://github.com/bitfinexcom/bfx-report-ui/pull/802)
- Extended and improved click tracking all across the `Reports`. PR: [bfx-report-ui#803](https://github.com/bitfinexcom/bfx-report-ui/pull/803)
- Enhanced `Reports` navigation menu representation. PR: [bfx-report-ui#804](https://github.com/bitfinexcom/bfx-report-ui/pull/804)

### Fixed

- Fixed `action` prop passing for the `WS` in case an error. PR: [bfx-report-express#38](https://github.com/bitfinexcom/bfx-report-express/pull/38)
