### PR TITLE
Show native notifications with multiple workspaces mode in Ubuntu/Mac

### DIFF
--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -242,7 +242,10 @@ module.exports = (ipc) => {
           state === PROCESS_MESSAGES.READY_TRX_TAX_REPORT ||
           state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
         ) &&
-        !wins?.mainWindow?.isVisible()
+        (
+          !wins?.mainWindow?.isVisible() ||
+          !wins?.mainWindow?.isFocused()
+        )
       ) {
         const isError = state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
         const body = isError


### PR DESCRIPTION
This PR adds ability to show native notifications in case another screen is displayed and the app window is not hidden with multiple workspaces mode in Ubuntu/Mac

![Screenshot from 2024-08-02 12-31-25](https://github.com/user-attachments/assets/4d165647-0164-40db-b884-9e9e33a77ee3)
