### PR TITLE
Show native notification for sync if processing with hidden main window

### DIFF
--- a/server.js
+++ b/server.js
@@ -61,6 +61,9 @@ const allowedProcessMessagesSet = _getAllowedStatesSet({
     'READY_TRX_TAX_REPORT',
     'ERROR_TRX_TAX_REPORT',
 
+    'READY_SYNC',
+    'ERROR_SYNC',
+
     'ALL_TABLE_HAVE_BEEN_CLEARED',
     'ALL_TABLE_HAVE_NOT_BEEN_CLEARED',
 

--- a/src/helpers/manage-window.js
+++ b/src/helpers/manage-window.js
@@ -111,8 +111,16 @@ const centerWindow = (win, workArea) => {
   win.setBounds(boundsOpts)
 }
 
+const isWindowInvisible = (win) => {
+  return (
+    !win?.isVisible() ||
+    !win?.isFocused()
+  )
+}
+
 module.exports = {
   hideWindow,
   showWindow,
-  centerWindow
+  centerWindow,
+  isWindowInvisible
 }

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -14,7 +14,7 @@ const {
   showWindow
 } = require('./helpers/manage-window')
 const showTrxTaxReportNotification = require(
-  './show-trx-tax-report-notification'
+  './show-notification/show-trx-tax-report-notification'
 )
 const showSyncNotification = require(
   './show-notification/show-sync-notification'

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -14,8 +14,12 @@ const {
   showWindow,
   isWindowInvisible
 } = require('./helpers/manage-window')
-const showNotification = require('./show-notification')
-const showSyncNotification = require('./show-notification/show-sync-notification')
+const showTrxTaxReportNotification = require(
+  './show-trx-tax-report-notification'
+)
+const showSyncNotification = require(
+  './show-notification/show-sync-notification'
+)
 const PROCESS_MESSAGES = require(
   '../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
 )
@@ -242,19 +246,10 @@ module.exports = (ipc) => {
         ipc.send({ state: PROCESS_STATES.REMOVE_ALL_TABLES })
       }
       if (
-        (
-          state === PROCESS_MESSAGES.READY_TRX_TAX_REPORT ||
-          state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
-        ) &&
-        isWindowInvisible(wins?.mainWindow)
+        state === PROCESS_MESSAGES.READY_TRX_TAX_REPORT ||
+        state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
       ) {
-        const isError = state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
-        const body = isError
-          ? 'An unexpected error occurred while generating the tax report!'
-          : 'Your tax report is ready!'
-        const urgency = isError ? 'critical' : 'normal'
-
-        showNotification({ body, urgency })
+        showTrxTaxReportNotification(mess)
       }
       if (
         (

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -10,8 +10,12 @@ const showMessageModalDialog = require(
 const isMainWinAvailable = require(
   './helpers/is-main-win-available'
 )
-const { showWindow } = require('./helpers/manage-window')
+const {
+  showWindow,
+  isWindowInvisible
+} = require('./helpers/manage-window')
 const showNotification = require('./show-notification')
+const showSyncNotification = require('./show-notification/show-sync-notification')
 const PROCESS_MESSAGES = require(
   '../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
 )
@@ -242,10 +246,7 @@ module.exports = (ipc) => {
           state === PROCESS_MESSAGES.READY_TRX_TAX_REPORT ||
           state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
         ) &&
-        (
-          !wins?.mainWindow?.isVisible() ||
-          !wins?.mainWindow?.isFocused()
-        )
+        isWindowInvisible(wins?.mainWindow)
       ) {
         const isError = state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
         const body = isError
@@ -254,6 +255,15 @@ module.exports = (ipc) => {
         const urgency = isError ? 'critical' : 'normal'
 
         showNotification({ body, urgency })
+      }
+      if (
+        (
+          state === PROCESS_MESSAGES.READY_SYNC ||
+          state === PROCESS_MESSAGES.ERROR_SYNC
+        ) &&
+        isWindowInvisible(wins?.mainWindow)
+      ) {
+        showSyncNotification(mess)
       }
     } catch (err) {
       console.error(err)

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -11,8 +11,7 @@ const isMainWinAvailable = require(
   './helpers/is-main-win-available'
 )
 const {
-  showWindow,
-  isWindowInvisible
+  showWindow
 } = require('./helpers/manage-window')
 const showTrxTaxReportNotification = require(
   './show-trx-tax-report-notification'
@@ -252,11 +251,8 @@ module.exports = (ipc) => {
         showTrxTaxReportNotification(mess)
       }
       if (
-        (
-          state === PROCESS_MESSAGES.READY_SYNC ||
-          state === PROCESS_MESSAGES.ERROR_SYNC
-        ) &&
-        isWindowInvisible(wins?.mainWindow)
+        state === PROCESS_MESSAGES.READY_SYNC ||
+        state === PROCESS_MESSAGES.ERROR_SYNC
       ) {
         showSyncNotification(mess)
       }

--- a/src/show-notification/show-sync-notification.js
+++ b/src/show-notification/show-sync-notification.js
@@ -3,7 +3,7 @@
 const PROCESS_MESSAGES = require(
   '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
 )
-const wins = require('./windows')
+const wins = require('../windows')
 const { isWindowInvisible } = require('../helpers/manage-window')
 const showNotification = require('./')
 

--- a/src/show-notification/show-sync-notification.js
+++ b/src/show-notification/show-sync-notification.js
@@ -3,6 +3,8 @@
 const PROCESS_MESSAGES = require(
   '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
 )
+const wins = require('./windows')
+const { isWindowInvisible } = require('../helpers/manage-window')
 const showNotification = require('./')
 
 const getBody = (params) => {
@@ -26,6 +28,10 @@ module.exports = (mess) => {
     state = '',
     data = {}
   } = mess ?? {}
+
+  if (!isWindowInvisible(wins?.mainWindow)) {
+    return
+  }
 
   const isError = state === PROCESS_MESSAGES.ERROR_SYNC
   const isInterrupted = !!data?.isInterrupted

--- a/src/show-notification/show-sync-notification.js
+++ b/src/show-notification/show-sync-notification.js
@@ -1,0 +1,37 @@
+'use strict'
+
+const PROCESS_MESSAGES = require(
+  '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
+)
+const showNotification = require('./')
+
+const getBody = (params) => {
+  const {
+    isError,
+    isInterrupted
+  } = params ?? {}
+
+  if (isError) {
+    return 'Data sync completed with an error!'
+  }
+  if (isInterrupted) {
+    return 'Data sync interrupted!'
+  }
+
+  return 'Data sync completed successfully!'
+}
+
+module.exports = (mess) => {
+  const {
+    state = '',
+    data = {}
+  } = mess ?? {}
+
+  const isError = state === PROCESS_MESSAGES.ERROR_SYNC
+  const isInterrupted = !!data?.isInterrupted
+
+  const body = getBody({ isError, isInterrupted })
+  const urgency = isError ? 'critical' : 'normal'
+
+  showNotification({ body, urgency })
+}

--- a/src/show-notification/show-trx-tax-report-notification.js
+++ b/src/show-notification/show-trx-tax-report-notification.js
@@ -1,0 +1,26 @@
+'use strict'
+
+const PROCESS_MESSAGES = require(
+  '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
+)
+const wins = require('./windows')
+const { isWindowInvisible } = require('../helpers/manage-window')
+const showNotification = require('.')
+
+module.exports = (mess) => {
+  const {
+    state = ''
+  } = mess ?? {}
+
+  if (!isWindowInvisible(wins?.mainWindow)) {
+    return
+  }
+
+  const isError = state === PROCESS_MESSAGES.ERROR_TRX_TAX_REPORT
+  const body = isError
+    ? 'An unexpected error occurred while generating the tax report!'
+    : 'Your tax report is ready!'
+  const urgency = isError ? 'critical' : 'normal'
+
+  showNotification({ body, urgency })
+}

--- a/src/show-notification/show-trx-tax-report-notification.js
+++ b/src/show-notification/show-trx-tax-report-notification.js
@@ -3,9 +3,9 @@
 const PROCESS_MESSAGES = require(
   '../../bfx-reports-framework/workers/loc.api/process.message.manager/process.messages'
 )
-const wins = require('./windows')
+const wins = require('../windows')
 const { isWindowInvisible } = require('../helpers/manage-window')
-const showNotification = require('.')
+const showNotification = require('./')
 
 module.exports = (mess) => {
   const {


### PR DESCRIPTION
This PR adds ability to show the native notification in the electron app in case the sync is being processed in the background with the hidden main window
There we check if the main window is invisible and show a notification otherwise don't

---

Example:

![Screenshot from 2024-08-09 07-18-02](https://github.com/user-attachments/assets/f484446a-6bf9-43dd-bda2-73b5165cd58a)

