### PR TITLE
Release version 4.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.26.0] - 2024-08-28
+
+### Added
+
+- Added ability to send `IPC` messages when the sync is ready. PR: [bfx-reports-framework#405](https://github.com/bitfinexcom/bfx-reports-framework/pull/405)
+- Added ability to show native notifications in case another screen is displayed and the app window is not hidden with multiple workspaces mode in `Ubuntu`/`Mac`. PR: [bfx-report-electron#389](https://github.com/bitfinexcom/bfx-report-electron/pull/389)
+- Added ability to show the native notification in the electron app in case the `sync` is being processed in the background with the hidden main window. There we check if the main window is invisible and show a notification otherwise don't. PR: [bfx-report-electron#390](https://github.com/bitfinexcom/bfx-report-electron/pull/390)
+
+### Changed
+
+- Enhanced and unified `Logins` and `Change Logs` reports column configuration getters and reduced redundant code. PR: [bfx-report-ui#840](https://github.com/bitfinexcom/bfx-report-ui/pull/840)
+- Reworked and optimized the `TimeFrameSelector` component in a more performant way and reduced redundant code. PR: [bfx-report-ui#841](https://github.com/bitfinexcom/bfx-report-ui/pull/841)
+- Reworked cell generation configurations more concisely and optimally for `Wallets`, `Weighted Averages` and `Concentration Risk` reports. PR: [bfx-report-ui#842](https://github.com/bitfinexcom/bfx-report-ui/pull/842)
+- Reworked and optimized `LedgersCategorySelect` in a more concise and performant way. PR: [bfx-report-ui#843](https://github.com/bitfinexcom/bfx-report-ui/pull/843)
+- Reworked and optimized `Movements`, `Trades`, `Orders` and `Positions` reports column configuration getters. Implemented unified `getFeeCell` and `getActionCell` helpers for better reusability. PR: [bfx-report-ui#844](https://github.com/bitfinexcom/bfx-report-ui/pull/844)
+- Reworked `CandlesTimeframe` in a more performant way and improved props linting. PR: [bfx-report-ui#845](https://github.com/bitfinexcom/bfx-report-ui/pull/845)
+- Enhanced and unified `Snapshots` sections column configuration getters and reduced redundant code. PR: [bfx-report-ui#846](https://github.com/bitfinexcom/bfx-report-ui/pull/846)
+- Removed deprecated methods and fields without breaking the logic and UI functionality. PRs: [bfx-report#389](https://github.com/bitfinexcom/bfx-report/pull/389), [bfx-reports-framework#403](https://github.com/bitfinexcom/bfx-reports-framework/pull/403)
+- Improved DB file cleanups for test coverage hooks. PRs: [bfx-report#390](https://github.com/bitfinexcom/bfx-report/pull/390), [bitfinexcom/lokue#3](https://github.com/bitfinexcom/lokue/pull/3)
+- Removed unused public colls conf accessor endpoints to use the common `getAllPublicCollsConfs`/`editAllPublicCollsConfs` ones without breaking the logic and UI functionality. PR: [bfx-reports-framework#404](https://github.com/bitfinexcom/bfx-reports-framework/pull/404)
+- Implemented a class for DB models to typify and unify model objects. PR: [bfx-reports-framework#406](https://github.com/bitfinexcom/bfx-reports-framework/pull/406)
+- Proxied `ENet` error tester for import in electron env. PR: [bfx-reports-framework#407](https://github.com/bitfinexcom/bfx-reports-framework/pull/407)
+
+### Fixed
+
+- Extended network error processing. Related to these issues: [bfx-report-electron#396](https://github.com/bitfinexcom/bfx-report-electron/issues/396), [bfx-report-electron#274](https://github.com/bitfinexcom/bfx-report-electron/issues/274). PR: [bfx-report#392](https://github.com/bitfinexcom/bfx-report/pull/392)
+- Improved the tax report ccy conversion by adding `6` retries with `10sec` delay for getting `pub-trades` if returns non-array. PR: [bfx-reports-framework#402](https://github.com/bitfinexcom/bfx-reports-framework/pull/402)
+- Extended network error processing and prevented showing the error modal dialog. Related to these issues: [bfx-report-electron#396](https://github.com/bitfinexcom/bfx-report-electron/issues/396), [bfx-report-electron#274](https://github.com/bitfinexcom/bfx-report-electron/issues/274). PR: [bfx-report-electron#397](https://github.com/bitfinexcom/bfx-report-electron/pull/397)
+
 ## [4.25.0] - 2024-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.27.0] - 2024-09-11
+
+### Added
+
+- Added `DNS` availability error processing: `net::ERR_NAME_NOT_RESOLVED`. PR: [bitfinexcom/bfx-report#395](https://github.com/bitfinexcom/bfx-report/pull/395)
+- Added `socket hang up` error processing as `ENet` error. PR: [bfx-report#396](https://github.com/bitfinexcom/bfx-report/pull/396)
+- Added common net `net::ERR_` error processing as `ENet` error. PR: [bfx-report#397](https://github.com/bitfinexcom/bfx-report/pull/397)
+- Implemented endpoint to get the last finished sync timestamp for the UI/UX. PR: [bfx-reports-framework#410](https://github.com/bitfinexcom/bfx-reports-framework/pull/410)
+- Implemented the possibility of `Cancel` the generation process for the tax report. PR: [bfx-report-ui#854](https://github.com/bitfinexcom/bfx-report-ui/pull/854)
+
+### Changed
+
+- Improved the interruption flow of getting data from the `BFX API` for the tax report, provided event-driven flow after delay processing, speeded up interruption not to wait for timeout in case of a slow internet connection. PRs: [bfx-report#399](https://github.com/bitfinexcom/bfx-report/pull/399), [bfx-reports-framework#411](https://github.com/bitfinexcom/bfx-reports-framework/pull/411)
+- Reworked DB model usage to use the new model interface implemented, speeded up the work by avoiding the usage of `cloneDeep` fn based on `JSON.parse(JSON.stringify(obj))` for the models. PR: [bfx-reports-framework#412](https://github.com/bitfinexcom/bfx-reports-framework/pull/412)
+- Removed duplicate buttons with the same functionality, improved and unified reports refreshing flow. PR: [bfx-report-ui#852](https://github.com/bitfinexcom/bfx-report-ui/pull/852)
+- Reworked and enhanced navigation tabs positioning and representation to be more consistent all across the app. Adjusted app `Summary` section spacing. PR: [bfx-report-ui#853](https://github.com/bitfinexcom/bfx-report-ui/pull/853)
+
+### Fixed
+
+- Fixed `node-fetch` timeout error processing for slow network connection. PR: [bfx-report#398](https://github.com/bitfinexcom/bfx-report/pull/398)
+
+### Security
+
+- Bumped `webpack` from `5.90.0` to `5.94.0`, `axios` from `1.6.7` to `1.7.4`. PR: [bfx-report-ui#851](https://github.com/bitfinexcom/bfx-report-ui/pull/851)
+
 ## [4.26.0] - 2024-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.28.0] - 2024-09-25
+
+### Added
+
+- Implemented dynamic height calculation for the `Concentration Risk` pie chart to prevent overflow issues possibility spotted in some cases. PR: [bfx-report-ui#859](https://github.com/bitfinexcom/bfx-report-ui/pull/859)
+- Implemented `Last Sync time` handling and representation (approximately in hours) for the `Reports`. PR: [bfx-report-ui#863](https://github.com/bitfinexcom/bfx-report-ui/pull/863)
+- Implemented `Profits` section (port of the `Win/Loss` chart with several predefined parameters) on the app `Summary` page. Removed charts smoothness for better precision. PR: [bfx-report-ui#864](https://github.com/bitfinexcom/bfx-report-ui/pull/864)
+- Added logic to have separated translations by language in `JSON` files using `i18next` lib for easier translation maintenance. PRs: [bfx-report#402](https://github.com/bitfinexcom/bfx-report/pull/402), [bfx-reports-framework#417](https://github.com/bitfinexcom/bfx-reports-framework/pull/417)
+
+### Changed
+
+- Improved user notification and auth flow behavior for the cases when the user tries to re-add an existing account via email/password. PR: [bfx-report-ui#860](https://github.com/bitfinexcom/bfx-report-ui/pull/860)
+
+### Fixed
+
+- Improved `Docker`/`Terraform` deployment, fixed `html-pdf` module usage under Docker container with using docker container based on the `Debian` image to make `html-pdf` module workable, fixed deprecation warnings. PR: [bfx-reports-framework#415](https://github.com/bitfinexcom/bfx-reports-framework/pull/415)
+- Fixed an infrequent case for `process.send()` when the app is on its way to being closed and the child process channel is closed but the worker still sends a message to the main one. PR: [bfx-reports-framework#416](https://github.com/bitfinexcom/bfx-reports-framework/pull/416)
+
+### Security
+
+- Bumped `path-to-regexp` from `1.8.0` to `1.9.0`, `express` from `4.19.2` to `4.21.0`. PR: [bfx-report-ui#858](https://github.com/bitfinexcom/bfx-report-ui/pull/858)
+
 ## [4.27.0] - 2024-09-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ npm run launch -- -aop
 ```
 
 > Also, we provide [GitHub Actioins workflows](https://docs.github.com/en/actions/using-workflows/about-workflows) configs for automated building and publishing of the Electron app artifacts using the above-described scripts `./scripts/launch.sh` and `./scripts/build-release.sh`, see the corresponding file `.github/workflows/build-electron-app.yml`
+
+## Locations of ElectronJS App files on different OSs
+
+- Logs:
+  - Ubuntu: `~/.config/Bitfinex Report/logs`
+  - Windows: `C:\Users\$username\AppData\Roaming\Bitfinex Report\logs`
+  - Mac: ElectronJS logs: `~/Library/Logs/Bitfinex Report` and app logs `~/Library/Application Support/Bitfinex Report/logs`
+- DB files `db-sqlite_sync_m0.db`, `db-sqlite_sync_m0.db-shm` (optional), `db-sqlite_sync_m0.db-wal` (optional):
+  - Ubuntu: `~/.config/Bitfinex Report`
+  - Windows: `C:\Users\$username\AppData\Roaming\Bitfinex Report`
+  - Mac: `~/Library/Application Support/Bitfinex Report`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.27.0",
+  "version": "4.28.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.25.0",
+  "version": "4.26.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.26.0",
+  "version": "4.27.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/src/error-manager/index.js
+++ b/src/error-manager/index.js
@@ -6,6 +6,10 @@ const cleanStack = require('clean-stack')
 
 const isDevEnv = process.env.NODE_ENV === 'development'
 
+const { isENetError } = require(
+  '../../bfx-reports-framework/workers/loc.api/helpers/api-errors-testers'
+)
+
 const log = require('./log')
 const getErrorDescription = require('./get-error-description')
 const showModalDialog = require('./show-modal-dialog')
@@ -216,8 +220,8 @@ const initLogger = () => {
        *   - GitHub server can't respond to the auto-update requests
        */
       if (
+        isENetError(error) ||
         /Cannot download differentially/gi.test(error) ||
-        /ERR_CONNECTION_REFUSED/gi.test(error) ||
         /objects\.githubusercontent\.com/gi.test(error) ||
         /Error: ERR_FAILED \(-2\) loading 'file:.*\.html'/gi.test(error) ||
         /Failed to generate PDF/gi.test(error)


### PR DESCRIPTION
## [4.28.0] - 2024-09-25

### Added

- Implemented dynamic height calculation for the `Concentration Risk` pie chart to prevent overflow issues possibility spotted in some cases. PR: [bfx-report-ui#859](https://github.com/bitfinexcom/bfx-report-ui/pull/859)
- Implemented `Last Sync time` handling and representation (approximately in hours) for the `Reports`. PR: [bfx-report-ui#863](https://github.com/bitfinexcom/bfx-report-ui/pull/863)
- Implemented `Profits` section (port of the `Win/Loss` chart with several predefined parameters) on the app `Summary` page. Removed charts smoothness for better precision. PR: [bfx-report-ui#864](https://github.com/bitfinexcom/bfx-report-ui/pull/864)
- Added logic to have separated translations by language in `JSON` files using `i18next` lib for easier translation maintenance. PRs: [bfx-report#402](https://github.com/bitfinexcom/bfx-report/pull/402), [bfx-reports-framework#417](https://github.com/bitfinexcom/bfx-reports-framework/pull/417)

### Changed

- Improved user notification and auth flow behavior for the cases when the user tries to re-add an existing account via email/password. PR: [bfx-report-ui#860](https://github.com/bitfinexcom/bfx-report-ui/pull/860)

### Fixed

- Improved `Docker`/`Terraform` deployment, fixed `html-pdf` module usage under Docker container with using docker container based on the `Debian` image to make `html-pdf` module workable, fixed deprecation warnings. PR: [bfx-reports-framework#415](https://github.com/bitfinexcom/bfx-reports-framework/pull/415)
- Fixed an infrequent case for `process.send()` when the app is on its way to being closed and the child process channel is closed but the worker still sends a message to the main one. PR: [bfx-reports-framework#416](https://github.com/bitfinexcom/bfx-reports-framework/pull/416)

### Security

- Bumped `path-to-regexp` from `1.8.0` to `1.9.0`, `express` from `4.19.2` to `4.21.0`. PR: [bfx-report-ui#858](https://github.com/bitfinexcom/bfx-report-ui/pull/858)
