### PR TITLE
Update macOS on GH Actions

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -128,7 +128,7 @@ jobs:
 
   mac-builder:
     timeout-minutes: 150
-    runs-on: macos-12
+    runs-on: macos-15
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -292,7 +292,7 @@ jobs:
   mac-e2e-test-runner:
     name: Mac E2E Test Runner
     timeout-minutes: 30
-    runs-on: macos-12
+    runs-on: macos-15
     needs: [mac-builder]
     steps:
     - name: Checkout

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean-stack": "3.0.1",
     "compare-versions": "4.1.1",
     "cron-validate": "1.4.3",
-    "ed25519-supercop": "2.0.1",
     "electron-alert": "0.1.20",
     "electron-log": "4.4.8",
     "electron-root-path": "1.0.16",

--- a/scripts/helpers/install-backend-deps.sh
+++ b/scripts/helpers/install-backend-deps.sh
@@ -56,7 +56,6 @@ function installBackendDeps {
 
   echo -e "\n${COLOR_BLUE}Installing the main prod deps...${COLOR_NORMAL}"
   npm i --production --include=dev --no-audit --progress=false --force
-  rm -rf "$ROOT/node_modules/ed25519-supercop/build"
   checkNodeModulesDir "$ROOT"
   depsErr=$(npm ls --depth=0 --only=prod 2>&1 >/dev/null | grep -E -v "missing: eslint|--omit=dev" || [[ $? == 1 ]])
   if [ -n "$depsErr" ]; then


### PR DESCRIPTION
This PR updates `macOS` on GH Actions from `12` to `15` due to caught warning on the last release:
- https://github.com/bitfinexcom/bfx-report-electron/actions/runs/11010191592

![Screenshot from 2024-09-24 12-44-51](https://github.com/user-attachments/assets/a7da1012-8b6a-458f-8370-35e4bf6821de)

---

Another issue here after updating macOS to `15` is a failure on `ed25519-supercop` dependency binary building:
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/11157362245/job/31011500800

And as we removed `ed25519-supercop` from `grenache-grape` https://github.com/bitfinexcom/grenache-grape/commit/f6715d6cdd6cc3ff9cd476538aab8301bc809b3e we can drop integration steps from electron app build flow
It was built and tested on GH Actions:
- https://github.com/ZIMkaRU/bfx-report-electron/releases/tag/v4.29.0-beta.1
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/11158307513
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/11158457763
