### PR TITLE
Fix dotenv importing for prod env

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -1,6 +1,9 @@
 'use strict'
 
-require('dotenv').config()
+try {
+  require('dotenv').config()
+} catch (err) {}
+
 const fs = require('fs')
 const path = require('path')
 const zlib = require('zlib')


### PR DESCRIPTION
This PR fixes `dotenv` importing for prod env

---

We use `dotenv` in `electron-builder` config file to build binaries and this dependency is in the dev section. It needs to exclude importing `dotenv` under prod env as we use that config file in the main code (not only for assembly), but `dotenv` is redundant here