### PR TITLE
Fix docker container preparation for release building

### DIFF
--- a/scripts/helpers/install-nodejs.sh
+++ b/scripts/helpers/install-nodejs.sh
@@ -25,7 +25,7 @@ unlink /usr/local/CHANGELOG.md
 unlink /usr/local/LICENSE
 unlink /usr/local/README.md
 
-npm cache clear --force
+npm cache clear --force 2>/dev/null
 npm install --global node-gyp@9.4.0
 
 echo -e "\n${COLOR_GREEN}The NodeJS has been installed successful${COLOR_NORMAL}"


### PR DESCRIPTION
This PR fixes Docker container preparation for release building

---

The nodejs installation script began to throw an error after `npm cache clear`. In this case, we can omit the error

![Screenshot from 2024-10-10 09-03-21](https://github.com/user-attachments/assets/89d8ad55-8f6a-4910-915c-f3488e8fe6e1)
