### PR TITLE
Extend electron app wrapper translations

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -1,6 +1,10 @@
 {
   "common": {
-    "title": "Report"
+    "title": "Report",
+    "appInitError": {
+      "description": "Application initialization error",
+      "closeBtnText": "Close"
+    }
   },
   "menu": {
     "macMainSubmenu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -1,6 +1,10 @@
 {
   "common": {
-    "title": "Отчет"
+    "title": "Отчет",
+    "appInitError": {
+      "description": "Ошибка инициализации приложения",
+      "closeBtnText": "Закрыть"
+    }
   },
   "menu": {
     "macMainSubmenu": {

--- a/src/error-manager/collect-logs.js
+++ b/src/error-manager/collect-logs.js
@@ -1,10 +1,11 @@
 'use strict'
 
-const { app } = require('electron')
 const { promisify } = require('util')
 const path = require('path')
 const fs = require('fs')
 const log = require('electron-log')
+
+const getUserDataPath = require('../helpers/get-user-data-path')
 
 const readFile = promisify(fs.readFile)
 
@@ -35,7 +36,7 @@ const _readLogFile = async (logPath, byteLimit = 8000) => {
 module.exports = async () => {
   const { path: mainLogPath } = log.transports.file.getFile()
 
-  const pathToUserData = app.getPath('userData')
+  const pathToUserData = getUserDataPath()
   const logsFolder = path.join(pathToUserData, 'logs')
   const workerErrorsPath = path.join(
     logsFolder,

--- a/src/error-manager/show-modal-dialog.js
+++ b/src/error-manager/show-modal-dialog.js
@@ -212,14 +212,25 @@ module.exports = async (params) => {
   }
 
   // On Linux needs to spawn zenity gui tool to show error
-  await spawn('zenity', [
-    '--error',
-    `--title=${errBoxTitle}`,
-    `--text=${errBoxDescription}`,
-    '--width=800',
-    '--ok-label=Exit',
-    '--no-markup'
-  ])
+  // If push close btn in menu bar zenity will exit with 1
+  // which will cause an error
+  try {
+    await spawn('zenity', [
+      '--error',
+      `--title=${errBoxTitle}`,
+      `--text=${errBoxDescription}`,
+      '--width=800',
+      '--ok-label=Report and Exit',
+      '--no-markup'
+    ])
+  } catch (err) {
+    console.debug(err)
+
+    return {
+      isExit: true,
+      isReported: false
+    }
+  }
 
   return res
 }

--- a/src/helpers/get-user-data-path.js
+++ b/src/helpers/get-user-data-path.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const { app } = require('electron')
+
+const productName = require('./product-name')
+
+module.exports = () => {
+  return app.getPath('userData')
+    .replace('bfx-report-electron', productName)
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,6 +13,7 @@ const isMainWinAvailable = require(
   './is-main-win-available'
 )
 const productName = require('./product-name')
+const getUserDataPath = require('./get-user-data-path')
 const getAlertCustomClassObj = require('./get-alert-custom-class-obj')
 const parseEnvValToBool = require('./parse-env-val-to-bool')
 const isBfxApiStaging = require('./is-bfx-api-staging')
@@ -26,6 +27,7 @@ module.exports = {
   getServerPromise,
   isMainWinAvailable,
   productName,
+  getUserDataPath,
   getAlertCustomClassObj,
   parseEnvValToBool,
   isBfxApiStaging,

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -13,7 +13,6 @@ const isMainWinAvailable = require(
   './is-main-win-available'
 )
 const productName = require('./product-name')
-const getUserDataPath = require('./get-user-data-path')
 const getAlertCustomClassObj = require('./get-alert-custom-class-obj')
 const parseEnvValToBool = require('./parse-env-val-to-bool')
 const isBfxApiStaging = require('./is-bfx-api-staging')
@@ -27,7 +26,6 @@ module.exports = {
   getServerPromise,
   isMainWinAvailable,
   productName,
-  getUserDataPath,
   getAlertCustomClassObj,
   parseEnvValToBool,
   isBfxApiStaging,

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -34,9 +34,9 @@ const {
 } = require('./errors')
 const {
   deserializeError,
-  getFreePort,
-  getUserDataPath
+  getFreePort
 } = require('./helpers')
+const getUserDataPath = require('./helpers/get-user-data-path')
 const {
   checkForUpdatesAndNotify
 } = require('./auto-updater')

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -9,6 +9,9 @@ const { REPORT_FILES_PATH_VERSION } = require('./const')
 const TranslationIpcChannelHandlers = require(
   './window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers'
 )
+const GeneralIpcChannelHandlers = require(
+  './window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers'
+)
 const triggerSyncAfterUpdates = require('./trigger-sync-after-updates')
 const triggerElectronLoad = require('./trigger-electron-load')
 const wins = require('./window-creators/windows')
@@ -158,6 +161,7 @@ const _manageConfigs = (params = {}) => {
 
 module.exports = async () => {
   try {
+    GeneralIpcChannelHandlers.create()
     TranslationIpcChannelHandlers.create()
 
     app.on('window-all-closed', () => {

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -31,7 +31,8 @@ const {
 } = require('./errors')
 const {
   deserializeError,
-  getFreePort
+  getFreePort,
+  getUserDataPath
 } = require('./helpers')
 const {
   checkForUpdatesAndNotify
@@ -157,6 +158,8 @@ const _manageConfigs = (params = {}) => {
 
 module.exports = async () => {
   try {
+    TranslationIpcChannelHandlers.create()
+
     app.on('window-all-closed', () => {
       app.quit()
     })
@@ -169,7 +172,7 @@ module.exports = async () => {
       app.setAppUserModelId(app.name)
     }
 
-    const pathToUserData = app.getPath('userData')
+    const pathToUserData = getUserDataPath()
     const pathToUserDocuments = app.getPath('documents')
 
     const configsKeeper = _manageConfigs({
@@ -181,8 +184,6 @@ module.exports = async () => {
     if (savedLanguage) {
       await i18next.changeLanguage(savedLanguage)
     }
-
-    TranslationIpcChannelHandlers.create()
 
     const secretKey = await makeOrReadSecretKey(
       { pathToUserData }
@@ -216,6 +217,7 @@ module.exports = async () => {
 
     printToPDF()
   } catch (err) {
+    await app.whenReady()
     await createErrorWindow(pathToLayoutAppInitErr)
 
     throw err

--- a/src/window-creators/index.js
+++ b/src/window-creators/index.js
@@ -307,8 +307,8 @@ const createErrorWindow = async (pathname) => {
     pathname,
     'errorWindow',
     {
-      height: 200,
-      frame: true
+      height: 300,
+      frame: false
     }
   )
 

--- a/src/window-creators/layouts/app-init-error.html
+++ b/src/window-creators/layouts/app-init-error.html
@@ -58,7 +58,38 @@
     </style>
   </head>
   <body class="body">
-    <div class="alert">Application initialization error</div>
-    <button type="button" class="btn-close" onclick="window.close()">Close</button>
+    <div id="description" class="alert">Application initialization error</div>
+    <button id="closeBtn" type="button" class="btn-close" onclick="window.close()">Close</button>
   </body>
+
+  <script>
+    window.addEventListener('load', async () => {
+      const descriptionElem = document.getElementById('description')
+      const closeBtnElem = document.getElementById('closeBtn')
+      const defaultDescription = 'Application initialization error'
+      const defaultCloseBtnText = 'Close'
+      let description = null
+      let closeBtnText = null
+
+      try {
+        description = await window.bfxReportElectronApi.translate({
+            key: 'common.appInitError.description',
+            opts: { defaultValue: defaultDescription }
+          }) ?? defaultDescription
+        closeBtnText = await window.bfxReportElectronApi.translate({
+            key: 'common.appInitError.closeBtnText',
+            opts: { defaultValue: defaultCloseBtnText }
+          }) ?? defaultCloseBtnText
+
+        descriptionElem.innerText = description
+        closeBtnElem.innerText = closeBtnText
+        
+      } catch (err) {
+        descriptionElem.innerText = description ??
+          `${defaultDescription}: translation service error`
+
+        console.error(err)
+      }
+    })
+  </script>
 </html>

--- a/src/window-creators/layouts/app-init-error.html
+++ b/src/window-creators/layouts/app-init-error.html
@@ -7,9 +7,17 @@
     <link href="../../../bfx-report-ui/build/fonts/roboto.css" rel="stylesheet">
     <title>Bitfinex Reports</title>
     <style>
+      html {
+        height: 100%;
+      }
+
       body {
         padding: 0;
         margin: 0;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
         text-align: center;
         background-color: #172d3e;
         font-family: "Roboto", sans-serif;
@@ -23,18 +31,24 @@
         font-size: 16px;
       }
 
+      .warning {
+        margin: 0 0 20px;
+        flex: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+
       .btn-close {
-        position: absolute;
-        bottom: 20px;
-        left: 50%;
-        transform: translateX(-50%);
+        align-self: center;
+        margin: 0 0 20px;
         cursor: pointer;
         display: inline-block;
         overflow: hidden;
         vertical-align: middle;
         z-index: 1;
         transition: .3s ease-out;
-        height: 40px;
+        min-height: 40px;
         min-width: 162px;
         font-size: 15px;
         padding: 5px 10px;
@@ -55,14 +69,47 @@
         background-color: #4c88c8;
         box-shadow: 0 3px 3px 0 rgba(0,0,0,0.14), 0 1px 7px 0 rgba(0,0,0,0.12), 0 3px 1px -1px rgba(0,0,0,0.2);
       }
+
+      .btn-close.btn-disabled {
+        box-shadow: none;
+        background-image: none;
+        color: rgba(255, 255, 255, 0.3);
+        border-color: transparent;
+        background-color: #50617180;
+        cursor: not-allowed;
+      }
     </style>
   </head>
   <body class="body">
     <div id="description" class="alert">Application initialization error</div>
-    <button id="closeBtn" type="button" class="btn-close" onclick="window.close()">Close</button>
+    <div class="warning">
+      <svg class="icon--warning" width="74" height="74" viewBox="0 0 74 74" fill="none" xmlns="http://www.w3.org/2000/svg">
+        <g clip-path="url(#clip0)">
+        <path d="M36.9746 32.2861L14.0432 71.5937L15.418 72.4039V73.9997H58.5312V72.4039L59.9059 71.5937L36.9746 32.2861ZM18.1925 70.8079L36.9746 38.6205L55.7566 70.8079H18.1925Z" fill="#F05359"/>
+        <path d="M38.572 53.9414H35.3801V67.7886H38.572V53.9414Z" fill="#F05359"/>
+        <path d="M38.572 47.7783H35.3801V50.8473H38.572V47.7783Z" fill="#F05359"/>
+        <path d="M63.5413 23.718C64.2042 21.6065 64.4741 19.4215 64.3269 17.1873C64.0568 12.6207 62.0682 8.32396 58.7291 5.08311C55.3899 1.84244 51.0689 0.0498437 46.5513 0.00083903C39.0137 -0.072855 32.3111 4.71482 29.6596 11.663C26.9343 9.42881 23.3988 8.32396 19.8146 8.69205C14.6584 9.23242 10.1655 12.8416 8.39779 17.8744C7.61222 20.0351 7.73492 23.0057 7.85762 24.5772C2.99625 27.8673 0.000976562 33.416 0.000976562 39.3084C0.000976562 49.1046 7.95581 57.0593 17.7519 57.0593C18.0465 57.0593 18.3657 57.0593 18.7093 57.0346L18.4148 53.8674C18.2184 53.8921 17.9975 53.8921 17.7519 53.8921C9.72353 53.8921 3.19282 47.3614 3.19282 39.333C3.19282 34.2263 5.9427 29.4141 10.3621 26.7869L11.2705 26.2468L11.1233 25.1909C10.9761 24.0861 10.7306 20.7962 11.3934 18.9548C12.7682 15.0511 16.1811 12.2767 20.1093 11.8839C23.5958 11.5403 26.9593 12.9643 29.1443 15.7139L31.2558 18.3409L31.9677 15.0511C33.4408 8.15207 39.4806 3.1925 46.3796 3.1925C46.4043 3.1925 46.4533 3.1925 46.5023 3.1925C54.1378 3.26619 60.693 9.6252 61.135 17.3833C61.2822 19.7649 60.8649 22.0973 59.9075 24.3315L59.0482 26.3448L61.2332 26.5657C66.6838 27.1058 70.8086 31.7461 70.8086 37.3441C70.8086 48.2942 65.5789 53.8429 55.2919 53.8429V57.0348C62.6573 57.0348 67.9607 54.5058 71.0541 49.4729C72.9939 46.281 74.0004 42.2056 74.0004 37.3444C74.0004 30.789 69.6304 25.2401 63.5413 23.718Z" fill="#F05359"/>
+        </g>
+        <defs>
+        <clipPath id="clip0">
+        <rect width="74" height="74" fill="white"/>
+        </clipPath>
+        </defs>
+      </svg>
+    </div>
+    <button id="closeBtn" type="button" class="btn-close">Close</button>
   </body>
 
   <script>
+    const disableBtn = (elem) => {
+      elem.classList.add("btn-disabled")
+      elem.disabled = true
+    }
+    const enableBtn = (elem) => {
+      elem.classList.remove("btn-disabled")
+      elem.disabled = false
+    }
+
     window.addEventListener('load', async () => {
       const descriptionElem = document.getElementById('description')
       const closeBtnElem = document.getElementById('closeBtn')
@@ -72,11 +119,11 @@
       let closeBtnText = null
 
       try {
-        description = await window.bfxReportElectronApi.translate({
+        description = await window.bfxReportElectronApi?.translate({
             key: 'common.appInitError.description',
             opts: { defaultValue: defaultDescription }
           }) ?? defaultDescription
-        closeBtnText = await window.bfxReportElectronApi.translate({
+        closeBtnText = await window.bfxReportElectronApi?.translate({
             key: 'common.appInitError.closeBtnText',
             opts: { defaultValue: defaultCloseBtnText }
           }) ?? defaultCloseBtnText
@@ -84,6 +131,16 @@
         descriptionElem.innerText = description
         closeBtnElem.innerText = closeBtnText
         
+        closeBtnElem.onclick = async () => {
+          try {
+            disableBtn(closeBtnElem)
+            await window.bfxReportElectronApi?.exit()
+            enableBtn(closeBtnElem)
+          } catch (err) {
+            enableBtn(closeBtnElem)
+            console.error(err)
+          }
+        }
       } catch (err) {
         descriptionElem.innerText = description ??
           `${defaultDescription}: translation service error`

--- a/src/window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers.js
+++ b/src/window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers.js
@@ -1,0 +1,13 @@
+'use strict'
+
+const { app } = require('electron')
+
+const IpcChannelHandlers = require('./ipc.channel.handlers')
+
+class GeneralIpcChannelHandlers extends IpcChannelHandlers {
+  async exitHandler (event, args) {
+    return app.exit(args?.code ?? 0)
+  }
+}
+
+module.exports = GeneralIpcChannelHandlers

--- a/src/window-creators/main-renderer-ipc-bridge/preload.js
+++ b/src/window-creators/main-renderer-ipc-bridge/preload.js
@@ -10,8 +10,13 @@ const CHANNEL_NAMES = {
 const INVOKE_METHOD_NAMES = {
   SET_LANGUAGE: 'setLanguage',
   GET_LANGUAGE: 'getLanguage',
-  GET_AVAILABLE_LANGUAGES: 'getAvailableLanguages'
+  GET_AVAILABLE_LANGUAGES: 'getAvailableLanguages',
+  TRANSLATE: 'translate'
 }
+
+const CHANNEL_MAP = new Map([
+  [CHANNEL_NAMES.TRANSLATIONS, INVOKE_METHOD_NAMES]
+])
 
 const getEventName = (channel, method) => {
   return `${channel}:${method}`
@@ -25,9 +30,11 @@ const invoke = (channel, method, args) => {
 
 const bfxReportElectronApi = {}
 
-for (const methodName of Object.values(INVOKE_METHOD_NAMES)) {
-  bfxReportElectronApi[methodName] = (args) => {
-    return invoke(CHANNEL_NAMES.TRANSLATIONS, methodName, args)
+for (const [channelName, invokeMethodNames] of CHANNEL_MAP) {
+  for (const methodName of Object.values(invokeMethodNames)) {
+    bfxReportElectronApi[methodName] = (args) => {
+      return invoke(channelName, methodName, args)
+    }
   }
 }
 

--- a/src/window-creators/main-renderer-ipc-bridge/preload.js
+++ b/src/window-creators/main-renderer-ipc-bridge/preload.js
@@ -4,10 +4,14 @@ const { contextBridge, ipcRenderer } = require('electron')
 const isTestEnv = process.env.NODE_ENV === 'test'
 
 const CHANNEL_NAMES = {
+  GENERAL: 'general',
   TRANSLATIONS: 'translations'
 }
 
-const INVOKE_METHOD_NAMES = {
+const GENERAL_INVOKE_METHOD_NAMES = {
+  EXIT: 'exit'
+}
+const TRANSLATIONS_INVOKE_METHOD_NAMES = {
   SET_LANGUAGE: 'setLanguage',
   GET_LANGUAGE: 'getLanguage',
   GET_AVAILABLE_LANGUAGES: 'getAvailableLanguages',
@@ -15,7 +19,8 @@ const INVOKE_METHOD_NAMES = {
 }
 
 const CHANNEL_MAP = new Map([
-  [CHANNEL_NAMES.TRANSLATIONS, INVOKE_METHOD_NAMES]
+  [CHANNEL_NAMES.GENERAL, GENERAL_INVOKE_METHOD_NAMES],
+  [CHANNEL_NAMES.TRANSLATIONS, TRANSLATIONS_INVOKE_METHOD_NAMES]
 ])
 
 const getEventName = (channel, method) => {

--- a/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
+++ b/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
@@ -10,8 +10,6 @@ const createMenu = require('../../create-menu')
 class TranslationIpcChannelHandlers extends IpcChannelHandlers {
   constructor () {
     super('translations')
-
-    this.configsKeeper = getConfigsKeeperByName('main')
   }
 
   async setLanguageHandler (event, args) {
@@ -32,8 +30,9 @@ class TranslationIpcChannelHandlers extends IpcChannelHandlers {
       createMenu()
     }
 
-    const isSaved = await this.configsKeeper
-      .saveConfigs({ language })
+    const configsKeeper = getConfigsKeeperByName('main')
+    const isSaved = await configsKeeper
+      ?.saveConfigs?.({ language })
 
     if (isSaved) {
       return language
@@ -48,6 +47,10 @@ class TranslationIpcChannelHandlers extends IpcChannelHandlers {
 
   async getAvailableLanguagesHandler (event, args) {
     return getAvailableLanguages()
+  }
+
+  async translateHandler (event, args) {
+    return i18next.t(args?.key, args?.opts)
   }
 }
 


### PR DESCRIPTION
This PR extends electron app wrapper translations, it's a part of the common task and here improves the app init error layout

---

Basic changes:
- Fix logs collection for bug report
- Improve app init to use translations in error layout
- Add ability to use translations in browser windows
- Add translations for app init error layout
- Use translations in app init error layout
- Fix `zenity` closing behavior for error modal win on `Ubuntu`. The context is if push close button in menu bar `zenity` will exit with `1` which will cause an error
- Add ability to use `app.exit()` method in the browser window of app init error layout
- Improve app init error layout

---

Example of the app init error layout:

![Screenshot from 2024-10-17 13-35-36](https://github.com/user-attachments/assets/2fe1184e-0ec2-4bfb-98d0-b45554279ea8)

