### PR TITLE
Improve app init layout launch flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "concurrently": "9.0.1",
     "cross-env": "7.0.3",
     "dotenv": "16.3.1",
-    "electron": "27.3.5",
+    "electron": "27.3.11",
     "electron-builder": "24.10.0",
     "mocha": "10.2.0",
     "standard": "17.1.0",

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -14,9 +14,7 @@ const GeneralIpcChannelHandlers = require(
 )
 const triggerSyncAfterUpdates = require('./trigger-sync-after-updates')
 const triggerElectronLoad = require('./trigger-electron-load')
-const wins = require('./window-creators/windows')
 const runServer = require('./run-server')
-const appStates = require('./app-states')
 const {
   createMainWindow,
   createErrorWindow
@@ -207,13 +205,6 @@ module.exports = async () => {
     manageWorkerMessages(ipc)
     await isServerReadyPromise
     await triggerSyncAfterUpdates()
-
-    // Legacy fix related to reprodducing the same behavior on all OS,
-    // waiting for checks that it was resolved in the last electron ver
-    if (appStates.isMainWinMaximized) {
-      wins.mainWindow.maximize()
-    }
-
     await hideLoadingWindow({ isRequiredToShowMainWin: true })
     await triggerElectronLoad(portsMap)
     await checkForUpdatesAndNotify()

--- a/src/window-creators/change-loading-win-visibility-state.js
+++ b/src/window-creators/change-loading-win-visibility-state.js
@@ -1,13 +1,17 @@
 'use strict'
 
-const { BrowserWindow, ipcMain } = require('electron')
+const { BrowserWindow } = require('electron')
 
 const wins = require('./windows')
+const appStates = require('../app-states')
 const {
   hideWindow,
   showWindow,
   centerWindow
 } = require('../helpers/manage-window')
+const GeneralIpcChannelHandlers = require(
+  './main-renderer-ipc-bridge/general-ipc-channel-handlers'
+)
 
 let intervalMarker
 
@@ -34,11 +38,20 @@ const _setParentWindow = (noParent) => {
 
   const win = BrowserWindow.getFocusedWindow()
 
-  if (
-    noParent ||
-    Object.values(wins).every((w) => w !== win)
-  ) {
+  if (noParent) {
     wins.loadingWindow.setParentWindow(null)
+
+    return
+  }
+  if (
+    Object.values(wins).every((w) => w !== win) ||
+    win === wins.loadingWindow
+  ) {
+    const mainWindow = !wins.mainWindow?.isDestroyed()
+      ? wins.mainWindow
+      : null
+
+    wins.loadingWindow.setParentWindow(mainWindow)
 
     return
   }
@@ -110,38 +123,31 @@ const _stopProgressLoader = (
   win.setProgressBar(-0.1)
 }
 
-const _setLoadingDescription = (win, description) => {
-  return new Promise((resolve) => {
-    try {
-      if (
-        !win ||
-        typeof win !== 'object' ||
-        win.isDestroyed() ||
-        typeof description !== 'string'
-      ) {
-        resolve()
-
-        return
-      }
-
-      ipcMain.once('loading:description-ready', (event, err) => {
-        if (err) {
-          console.error(err)
-        }
-
-        resolve()
-      })
-
-      win.webContents.send(
-        'loading:description',
-        description
-      )
-    } catch (err) {
-      console.error(err)
-
-      resolve()
+const _setLoadingDescription = async (win, description) => {
+  try {
+    if (
+      !win ||
+      typeof win !== 'object' ||
+      win.isDestroyed() ||
+      typeof description !== 'string'
+    ) {
+      return
     }
-  })
+
+    const loadingDescReadyPromise = GeneralIpcChannelHandlers
+      .onLoadingDescriptionReady()
+
+    GeneralIpcChannelHandlers
+      .sendLoadingDescription(win, { description })
+
+    const loadingRes = await loadingDescReadyPromise
+
+    if (loadingRes?.err) {
+      console.error(loadingRes?.err)
+    }
+  } catch (err) {
+    console.error(err)
+  }
 }
 
 const showLoadingWindow = async (opts = {}) => {
@@ -151,7 +157,7 @@ const showLoadingWindow = async (opts = {}) => {
     isNotRunProgressLoaderRequired = false,
     isIndeterminateMode = false,
     noParent = false
-  } = { ...opts }
+  } = opts ?? {}
 
   if (
     !wins.loadingWindow ||
@@ -188,14 +194,7 @@ const showLoadingWindow = async (opts = {}) => {
 const hideLoadingWindow = async (opts = {}) => {
   const {
     isRequiredToShowMainWin = false
-  } = { ...opts }
-
-  if (isRequiredToShowMainWin) {
-    await showWindow(
-      wins.mainWindow,
-      { shouldWinBeFocused: true }
-    )
-  }
+  } = opts ?? {}
 
   // need to empty description
   await _setLoadingDescription(
@@ -203,6 +202,19 @@ const hideLoadingWindow = async (opts = {}) => {
     ''
   )
   _stopProgressLoader()
+
+  if (isRequiredToShowMainWin) {
+    await showWindow(
+      wins.mainWindow,
+      { shouldWinBeFocused: true }
+    )
+
+    // Legacy fix related to reprodducing the same behavior on all OS,
+    // waiting for checks that it was resolved in the last electron ver
+    if (appStates.isMainWinMaximized) {
+      wins.mainWindow.maximize()
+    }
+  }
 
   return hideWindow(
     wins.loadingWindow,

--- a/src/window-creators/change-loading-win-visibility-state.js
+++ b/src/window-creators/change-loading-win-visibility-state.js
@@ -150,7 +150,7 @@ const _setLoadingDescription = async (win, description) => {
   }
 }
 
-const showLoadingWindow = async (opts = {}) => {
+const showLoadingWindow = async (opts) => {
   const {
     description = '',
     isRequiredToCloseAllWins = false,
@@ -191,7 +191,7 @@ const showLoadingWindow = async (opts = {}) => {
   await _closeAllWindows()
 }
 
-const hideLoadingWindow = async (opts = {}) => {
+const hideLoadingWindow = async (opts) => {
   const {
     isRequiredToShowMainWin = false
   } = opts ?? {}

--- a/src/window-creators/index.js
+++ b/src/window-creators/index.js
@@ -96,7 +96,6 @@ const _createWindow = async (
     height: defaultHeight
   } = workAreaSize
   const isMainWindow = winName === 'mainWindow'
-  const isLoadingWindow = winName === 'loadingWindow'
   const {
     width = defaultWidth,
     height = defaultHeight,
@@ -173,10 +172,7 @@ const _createWindow = async (
     centerWindow(wins[winName])
   }
 
-  await showWindow(
-    wins[winName],
-    { shouldWinBeShownInactive: isLoadingWindow }
-  )
+  await showWindow(wins[winName])
 
   return res
 }
@@ -278,12 +274,11 @@ const createLoadingWindow = async () => {
   if (
     wins.loadingWindow &&
     typeof wins.loadingWindow === 'object' &&
-    !wins.loadingWindow.isDestroyed() &&
-    !wins.loadingWindow.isVisible()
+    !wins.loadingWindow.isDestroyed()
   ) {
     await showLoadingWindow()
 
-    return {}
+    return { win: wins.loadingWindow }
   }
 
   const winProps = await _createChildWindow(
@@ -291,11 +286,7 @@ const createLoadingWindow = async () => {
     'loadingWindow',
     {
       width: 350,
-      height: 350,
-      webPreferences: {
-        nodeIntegration: true,
-        contextIsolation: false
-      }
+      height: 350
     }
   )
 

--- a/src/window-creators/layouts/app-init.html
+++ b/src/window-creators/layouts/app-init.html
@@ -217,28 +217,27 @@
       }
     }, 2500)
 
-    const { ipcRenderer } = require('electron')
-    
-    ipcRenderer.on('loading:description', (event, description) => {
+    window.bfxReportElectronApi?.onLoadingDescription((args) => {
       try {
-        if (typeof description !== 'string') {
+        if (typeof args?.description !== 'string') {
+          window.bfxReportElectronApi?.sendLoadingDescriptionReady()
+
           return
         }
 
-        descriptionElem.innerHTML = description
+        descriptionElem.innerHTML = args.description
 
-        descriptionElem.style.display = description
+        descriptionElem.style.display = args.description
           ? 'block'
           : 'none'
 
-        ipcRenderer.send('loading:description-ready')
+        window.bfxReportElectronApi?.sendLoadingDescriptionReady()
       } catch (err) {
         console.error(err)
 
-        ipcRenderer.send('loading:description-ready', err)
+        window.bfxReportElectronApi?.sendLoadingDescriptionReady({ err })
       }
     })
   })
 </script>
-
 </html>

--- a/src/window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers.js
+++ b/src/window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers.js
@@ -8,6 +8,14 @@ class GeneralIpcChannelHandlers extends IpcChannelHandlers {
   async exitHandler (event, args) {
     return app.exit(args?.code ?? 0)
   }
+
+  static onLoadingDescriptionReady (cb) {
+    return this.handleListener(this.onLoadingDescriptionReady, cb)
+  }
+
+  static sendLoadingDescription (win, args) {
+    return this.sendToRenderer(this.sendLoadingDescription, win, args)
+  }
 }
 
 module.exports = GeneralIpcChannelHandlers

--- a/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
+++ b/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
@@ -8,9 +8,7 @@ const { getAvailableLanguages } = require('../../i18next')
 const createMenu = require('../../create-menu')
 
 class TranslationIpcChannelHandlers extends IpcChannelHandlers {
-  constructor () {
-    super('translations')
-  }
+  static channelName = 'translations'
 
   async setLanguageHandler (event, args) {
     const lng = args?.language


### PR DESCRIPTION
This PR Improves the app-init layout launch flow

---

Basic changes:
- Adds ability to send/listen events for the app-init layout via the context bridge between the main and renderer ipc to be secure (the same approach as for other layouts)
- Improves the loading window workflow to bring more consistency in the sequence of showing windows. Fixes issue with focusing the main window on the launch
- Bumps `electron` version from `27.3.5` to `27.3.11` to have the latest patch
