### PR TITLE
Fix issue with Wine to build Windows release under container

### DIFF
--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -10,7 +10,7 @@ COPY ./scripts/helpers/install-nodejs.sh ./scripts/helpers/install-nodejs.sh
 RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
   # Remove the `Wine` source entry to resolve
   # the release key expiration issue for `apt-get update`
-  && sed -i '/Wine/d' /etc/apt/sources.list \
+  && rm -rf /etc/apt/sources.list.d/wine* \
   && apt-get update -y \
   && apt-get install -y --no-install-recommends \
     p7zip-full \


### PR DESCRIPTION
This PR fixes issue with `Wine` to build `Windows` release under container

---

The context of the issue:

![Screenshot from 2024-10-23 08-09-23](https://github.com/user-attachments/assets/87e68415-aaa8-403d-b320-5d138fd481ad)
![Screenshot from 2024-10-23 08-09-32](https://github.com/user-attachments/assets/11a10a2f-a2d9-4b18-98c3-a8dd7488134c)
