### PR TITLE
Prevent returning translation key if a value is missing

### DIFF
--- a/src/i18next/index.js
+++ b/src/i18next/index.js
@@ -72,9 +72,9 @@ const initI18next = () => {
   const configs = {
     initImmediate: false,
     fallbackLng: {
-      es: ['es-EM'],
-      pt: ['pt-BR'],
-      zh: ['zh-CN'],
+      es: ['es-EM', 'en'],
+      pt: ['pt-BR', 'en'],
+      zh: ['zh-CN', 'en'],
       default: ['en']
     },
     lng: _getDefaultLanguage(),


### PR DESCRIPTION
This PR prevents returning the translation key `key.nestedKey.etc` if a value is missing for a certain language and adds the ability to try to take one from the default `en` translation file