### PR TITLE
Add macos compatibility to sed cli usage

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -134,16 +134,12 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Replace macOS’s sed with GNU’s sed
-      run: |
-        brew install gnu-sed
-        echo "$(brew --prefix)/opt/gnu-sed/libexec/gnubin" >> $GITHUB_PATH
     - if: github.event.inputs.version != ''
       name: Set release version
       run: |
-        sed -i -e \
+        sed -i".bak" -E -e \
           "s/\"version\": \".*\"/\"version\": \"${{ github.event.inputs.version }}\"/g" \
-          "./package.json"
+          "./package.json"; rm -f "./package.json.bak"
     - if: contains(fromJson('["true", "1", true, 1]'), github.event.inputs.isAutoUpdateDisabled)
       name: Turn off auto-update
       run: |

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -141,24 +141,24 @@ fi
 if [ $isDevEnv == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Developer environment is turned on!${COLOR_NORMAL}"
 
-  sed -i -e \
+  sed -i".bak" -E -e \
     "s/\"NODE_ENV\": \".*\"/\"NODE_ENV\": \"development\"/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 else
-  sed -i -e \
+  sed -i".bak" -E -e \
     "s/\"NODE_ENV\": \".*\"/\"NODE_ENV\": \"production\"/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 fi
 if [ $isAutoUpdateDisabled == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Auto-update is turned off!${COLOR_NORMAL}"
 
-  sed -i -E -e \
+  sed -i".bak" -E -e \
     "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 else
-  sed -i -E -e \
+  sed -i".bak" -E -e \
     "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 fi
 
 changeDirOwnershipToCurrUser "$ELECTRON_CACHE" "$(id -u):$(id -g)"
@@ -186,9 +186,9 @@ cp "$EXPRESS_FOLDER/config/default.json.example" \
 echo -e "\n${COLOR_BLUE}Setting backend configs${COLOR_NORMAL}"
 
 escapedBfxApiUrl=$(escapeString $bfxApiUrl)
-sed -i -e \
+sed -i".bak" -E -e \
   "s/\"restUrl\": \".*\"/\"restUrl\": \"$escapedBfxApiUrl\"/g" \
-  "$WORKER_FOLDER/config/service.report.json"
+  "$WORKER_FOLDER/config/service.report.json"; rm -f "$WORKER_FOLDER/config/service.report.json.bak"
 
 installBackendDeps "$targetPlatform"
 

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -93,34 +93,34 @@ echo -e "\n${COLOR_BLUE}Setting UI configs${COLOR_NORMAL}"
 
 escapedBfxHomeUrl=$(escapeString $bfxHomeUrl)
 escapedBfxKeyUrl=$(escapeString $bfxKeyUrl)
-sed -i -e \
+sed -i".bak" -E -e \
   "s/HOME_URL: .*,/HOME_URL: \'$escapedBfxHomeUrl\',/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/API_URL: .*,/API_URL: \'http:\/\/${BACKEND_ADDRESS}\/api\',/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/WS_ADDRESS: .*,/WS_ADDRESS: \'ws:\/\/${BACKEND_ADDRESS}\/ws\',/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/KEY_URL: .*,/KEY_URL: \'$escapedBfxKeyUrl\/api\',/g" \
-  "$UI_CONFIGS_FILE"
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
 
-sed -i -e \
+sed -i".bak" -E -e \
   "s/localExport: false/localExport: true/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/showAuthPage: false/showAuthPage: true/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/showFrameworkMode: false/showFrameworkMode: true/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/hostedFrameworkMode: true/hostedFrameworkMode: false/g" \
-  "$UI_CONFIGS_FILE"
-sed -i -e \
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
+sed -i".bak" -E -e \
   "s/isElectronApp: false/isElectronApp: true/g" \
-  "$UI_CONFIGS_FILE"
+  "$UI_CONFIGS_FILE"; rm -f "$UI_CONFIGS_FILE.bak"
 
 cd "$UI_FOLDER"
 echo -e "\n${COLOR_BLUE}Installing the UI deps...${COLOR_NORMAL}"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -83,24 +83,24 @@ fi
 if [ $isDevEnv == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Developer environment is turned on!${COLOR_NORMAL}"
 
-  sed -i -e \
+  sed -i".bak" -E -e \
     "s/\"NODE_ENV\": \".*\"/\"NODE_ENV\": \"development\"/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 else
-  sed -i -e \
+  sed -i".bak" -E -e \
     "s/\"NODE_ENV\": \".*\"/\"NODE_ENV\": \"production\"/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 fi
 if [ $isAutoUpdateDisabled == 1 ]; then
   echo -e "\n${COLOR_YELLOW}Auto-update is turned off!${COLOR_NORMAL}"
 
-  sed -i -E -e \
+  sed -i".bak" -E -e \
     "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": true/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 else
-  sed -i -E -e \
+  sed -i".bak" -E -e \
     "s/\"IS_AUTO_UPDATE_DISABLED\": (false)|(true)/\"IS_AUTO_UPDATE_DISABLED\": false/g" \
-    "$ROOT/$ELECTRON_ENV_FILE_NAME"
+    "$ROOT/$ELECTRON_ENV_FILE_NAME"; rm -f "$ROOT/$ELECTRON_ENV_FILE_NAME.bak"
 fi
 
 if [ $syncRepo == 1 ]; then
@@ -132,9 +132,9 @@ cp "$EXPRESS_FOLDER/config/default.json.example" \
 echo -e "\n${COLOR_BLUE}Setting backend configs${COLOR_NORMAL}"
 
 escapedBfxApiUrl=$(escapeString $bfxApiUrl)
-sed -i -e \
+sed -i".bak" -E -e \
   "s/\"restUrl\": \".*\"/\"restUrl\": \"$escapedBfxApiUrl\"/g" \
-  "$WORKER_FOLDER/config/service.report.json"
+  "$WORKER_FOLDER/config/service.report.json"; rm -f "$WORKER_FOLDER/config/service.report.json.bak"
 
 installBackendDeps
 


### PR DESCRIPTION
This PR improves `bash` scripts to add `macos` compatibility to `sed` cli usage

---

The main changes are to rework `sed` commands to be able to run bash scripts on both OSs Ubuntu and MacOS as they have slightly different implementation
