### PR TITLE
Add translation support to restore db

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -57,6 +57,20 @@
         "title": "Update v{{version}} downloaded",
         "description": "Should the app be updated right now?"
       }
+    },
+    "restoreDB": {
+      "modalDialog": {
+        "title": "Select DB backup file",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Cancel"
+      },
+      "messageModalDialog": {
+        "title": "DB restoring",
+        "message": "Suitable DB backup file has not been found",
+        "dbRestoredMessage": "DB has been restored",
+        "dbNotRestoredMessage": "DB has not been restored",
+        "confirmButtonText": "OK"
+      }
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -57,6 +57,20 @@
         "title": "Обновление v{{version}} загружено",
         "description": "Стоит ли обновить приложение прямо сейчас?"
       }
+    },
+    "restoreDB": {
+      "modalDialog": {
+        "title": "Выберите файл резервной копии БД",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Отменить"
+      },
+      "messageModalDialog": {
+        "title": "Восстановление БД",
+        "message": "Подходящий файл резервной копии БД не найден",
+        "dbRestoredMessage": "БД была восстановлена",
+        "dbNotRestoredMessage": "БД не была восстановлена",
+        "confirmButtonText": "OK"
+      }
     }
   },
   "menu": {

--- a/src/helpers/get-ui-fonts-as-css-string.js
+++ b/src/helpers/get-ui-fonts-as-css-string.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const { rootPath } = require('electron-root-path')
+const fs = require('fs')
+const path = require('path')
+
+const fontsPath = path.join(rootPath, 'bfx-report-ui/build/fonts/')
+const fontsStyle = fs.readFileSync(
+  path.join(fontsPath, 'roboto.css'),
+  'utf8'
+)
+const fStyleWithNormalizedPaths = fontsStyle.replace(
+  /url\(\.\/(.*\..*)\)/g,
+  `url(${fontsPath}$1)`
+)
+
+module.exports = () => fStyleWithNormalizedPaths

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -17,6 +17,7 @@ const getAlertCustomClassObj = require('./get-alert-custom-class-obj')
 const parseEnvValToBool = require('./parse-env-val-to-bool')
 const isBfxApiStaging = require('./is-bfx-api-staging')
 const waitPort = require('./wait-port')
+const getUIFontsAsCSSString = require('./get-ui-fonts-as-css-string')
 
 module.exports = {
   getFreePort,
@@ -29,5 +30,6 @@ module.exports = {
   getAlertCustomClassObj,
   parseEnvValToBool,
   isBfxApiStaging,
-  waitPort
+  waitPort,
+  getUIFontsAsCSSString
 }

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { app, BrowserWindow } = require('electron')
+const i18next = require('i18next')
 
 const wins = require('./window-creators/windows')
 const relaunch = require('./relaunch')
@@ -27,10 +28,7 @@ const PROCESS_STATES = require(
 )
 
 module.exports = (ipc) => {
-  const win = isMainWinAvailable(
-    wins.mainWindow,
-    { shouldCheckVisibility: true }
-  )
+  const win = isMainWinAvailable(wins.mainWindow)
     ? wins.mainWindow
     : BrowserWindow.getFocusedWindow()
 
@@ -66,18 +64,17 @@ module.exports = (ipc) => {
         await showWindow(win)
 
         const hasNotDbBeenRestored = state === PROCESS_MESSAGES.DB_HAS_NOT_BEEN_RESTORED
-        const messChunk = hasNotDbBeenRestored
-          ? ' not'
-          : ''
         const type = hasNotDbBeenRestored
           ? 'error'
           : 'info'
 
         await showMessageModalDialog(win, {
           type,
-          title: 'DB restoring',
-          message: `DB has${messChunk} been restored`,
-          buttons: ['OK'],
+          title: i18next.t('common.restoreDB.messageModalDialog.title'),
+          message: hasNotDbBeenRestored
+            ? i18next.t('common.restoreDB.messageModalDialog.dbNotRestoredMessage')
+            : i18next.t('common.restoreDB.messageModalDialog.dbRestoredMessage'),
+          buttons: [i18next.t('common.restoreDB.messageModalDialog.confirmButtonText')],
           defaultId: 0,
           cancelId: 0
         })

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -101,7 +101,7 @@ const _fireAlert = (params) => {
     darkTheme: false,
     parent: win,
     modal: true,
-    width: 1000
+    minWidth: 1000
   }
   const swalOptions = {
     position: 'center',

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const path = require('path')
 const Alert = require('electron-alert')
 const { rootPath } = require('electron-root-path')
+const i18next = require('i18next')
 
 const ipcs = require('../ipcs')
 const wins = require('../window-creators/windows')
@@ -55,7 +56,7 @@ const sound = { freq: 'F2', type: 'triange', duration: 1.5 }
 
 const _fireAlert = (params) => {
   const {
-    title = 'Select DB backup file',
+    title = i18next.t('common.restoreDB.modalDialog.title'),
     backupFilesMetadata
   } = params
   const win = wins.mainWindow
@@ -121,7 +122,8 @@ const _fireAlert = (params) => {
     showConfirmButton: true,
     focusCancel: true,
     showCancelButton: true,
-    cancelButtonText: 'Cancel',
+    confirmButtonText: i18next.t('common.restoreDB.modalDialog.confirmButtonText'),
+    cancelButtonText: i18next.t('common.restoreDB.modalDialog.cancelButtonText'),
     timerProgressBar: false,
 
     input: 'radio',
@@ -238,9 +240,9 @@ module.exports = () => {
       ) {
         await showMessageModalDialog(wins.mainWindow, {
           type: 'warning',
-          title: 'DB restoring',
-          message: 'Suitable DB backup file has not been found',
-          buttons: ['OK'],
+          title: i18next.t('common.restoreDB.messageModalDialog.title'),
+          message: i18next.t('common.restoreDB.messageModalDialog.message'),
+          buttons: [i18next.t('common.restoreDB.messageModalDialog.confirmButtonText')],
           defaultId: 0,
           cancelId: 0
         })

--- a/src/restore-db/index.js
+++ b/src/restore-db/index.js
@@ -4,7 +4,6 @@ const { app, screen, remote } = require('electron')
 const fs = require('fs')
 const path = require('path')
 const Alert = require('electron-alert')
-const { rootPath } = require('electron-root-path')
 const i18next = require('i18next')
 
 const ipcs = require('../ipcs')
@@ -17,6 +16,9 @@ const isMainWinAvailable = require(
 )
 const getAlertCustomClassObj = require(
   '../helpers/get-alert-custom-class-obj'
+)
+const getUIFontsAsCSSString = require(
+  '../helpers/get-ui-fonts-as-css-string'
 )
 const showMessageModalDialog = require(
   '../show-message-modal-dialog'
@@ -32,9 +34,7 @@ const {
   addOnceProcEventHandler
 } = require('../window-creators/window-event-manager')
 
-const fontsStyle = fs.readFileSync(path.join(
-  rootPath, 'bfx-report-ui/build/fonts/roboto.css'
-))
+const fontsStyle = getUIFontsAsCSSString()
 const alertStyle = fs.readFileSync(path.join(
   __dirname, '../modal-dialog-src/modal-dialog.css'
 ))
@@ -101,10 +101,7 @@ const _fireAlert = (params) => {
     darkTheme: false,
     parent: win,
     modal: true,
-    width: 1000,
-    webPreferences: {
-      contextIsolation: false
-    }
+    width: 1000
   }
   const swalOptions = {
     position: 'center',


### PR DESCRIPTION
This PR adds translation support to the `restore-db`. And fixes loading ui fonts to `restore-db` modal window, fixes min-width for restore-db modal window

---

![Screenshot from 2024-11-01 12-04-40](https://github.com/user-attachments/assets/a301b724-8da1-4f6f-9ed8-39030d6a702b)

