### PR TITLE
Extend translations for auto-update buttons

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -33,6 +33,9 @@
       }
     },
     "autoUpdater": {
+      "title": "Update",
+      "confirmButtonText": "OK",
+      "cancelButtonText": "Cancel",
       "loadingWindow": {
         "description": "Updating..."
       },

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -33,6 +33,9 @@
       }
     },
     "autoUpdater": {
+      "title": "Обновление",
+      "confirmButtonText": "OK",
+      "cancelButtonText": "Отменить",
       "loadingWindow": {
         "description": "Обновление..."
       },

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -127,7 +127,7 @@ const _fireToast = (
     backgroundColor: '#172d3e',
     darkTheme: false,
     height,
-    width: opts?.width ?? 800,
+    width: opts?.width ?? 1000,
     parent: win,
     modal: false,
     webPreferences: {

--- a/src/auto-updater/index.js
+++ b/src/auto-updater/index.js
@@ -141,9 +141,11 @@ const _fireToast = (
     backdrop: 'rgba(0,0,0,0.0)',
 
     icon: 'info',
-    title: 'Update',
+    title: i18next.t('common.autoUpdater.title'),
     showConfirmButton: true,
     showCancelButton: false,
+    confirmButtonText: i18next.t('common.autoUpdater.confirmButtonText'),
+    cancelButtonText: i18next.t('common.autoUpdater.cancelButtonText'),
     timerProgressBar: false,
 
     ...opts,


### PR DESCRIPTION
This PR extends translations for the `auto-update` module buttons and also fixes the width for long text translations

---

Before:
![381855598-36eafb68-7c95-4dc0-8d27-f6ff7c60abba](https://github.com/user-attachments/assets/fdf825cb-2315-4102-bacd-bbf55b4d32c2)

After:
![Screenshot from 2024-11-07 13-15-55](https://github.com/user-attachments/assets/a80763ec-9b2f-4bca-88f8-99a79859b48e)


