### PR TITLE
Add translation support to enforce-macos-app-location module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -111,6 +111,21 @@
         "confirmButtonText": "OK",
         "cancelButtonText": "Cancel"
       }
+    },
+    "enforceMacOSAppLocation": {
+      "appLocationModalDialog": {
+        "message": "Move to Applications folder?",
+        "detail": "{{productName}} must live in the Applications folder to be able to run correctly",
+        "confirmButtonText": "Move to Applications folder",
+        "cancelButtonText": "Quit {{productName}}"
+      },
+      "loadingWindow": {
+        "description": "Moving the app..."
+      },
+      "appRunningModalDialog": {
+        "message": "Another version of {{productName}} is currently running. Quit it, then launch this version of the app again",
+        "confirmButtonText": "OK"
+      }
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -111,6 +111,21 @@
         "confirmButtonText": "OK",
         "cancelButtonText": "Отмена"
       }
+    },
+    "enforceMacOSAppLocation": {
+      "appLocationModalDialog": {
+        "message": "Переместить в папку Приложения?",
+        "detail": "{{productName}} должен находиться в папке Приложения для корректной работы",
+        "confirmButtonText": "Переместить в папку Приложения",
+        "cancelButtonText": "Выйти из {{productName}}"
+      },
+      "loadingWindow": {
+        "description": "Перемещение приложения..."
+      },
+      "appRunningModalDialog": {
+        "message": "В настоящее время запущена другая версия {{productName}}. Закройте ее, затем снова запустите эту версию приложения",
+        "confirmButtonText": "OK"
+      }
     }
   },
   "menu": {

--- a/src/enforce-macos-app-location.js
+++ b/src/enforce-macos-app-location.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { app, dialog } = require('electron')
+const i18next = require('i18next')
 
 const productName = require('./helpers/product-name')
 const {
@@ -22,11 +23,18 @@ module.exports = async () => {
 
   const clickedButtonIndex = dialog.showMessageBoxSync({
     type: 'error',
-    message: 'Move to Applications folder?',
-    detail: `${productName} must live in the Applications folder to be able to run correctly.`,
+    message: i18next
+      .t('common.enforceMacOSAppLocation.appLocationModalDialog.message'),
+    detail: i18next.t(
+      'common.enforceMacOSAppLocation.appLocationModalDialog.detail',
+      { productName }
+    ),
     buttons: [
-      'Move to Applications folder',
-      `Quit ${productName}`
+      i18next.t('common.enforceMacOSAppLocation.appLocationModalDialog.confirmButtonText'),
+      i18next.t(
+        'common.enforceMacOSAppLocation.appLocationModalDialog.cancelButtonText',
+        { productName }
+      )
     ],
     defaultId: 0,
     cancelId: 1
@@ -39,7 +47,8 @@ module.exports = async () => {
   }
 
   await showLoadingWindow({
-    description: 'Moving the app...',
+    description: i18next
+      .t('common.enforceMacOSAppLocation.loadingWindow.description'),
     isRequiredToCloseAllWins: true,
     isIndeterminateMode: true
   })
@@ -49,9 +58,12 @@ module.exports = async () => {
       if (conflict === 'existsAndRunning') {
         dialog.showMessageBoxSync({
           type: 'error',
-          message: `Another version of ${productName} is currently running. Quit it, then launch this version of the app again.`,
+          message: i18next.t(
+            'common.enforceMacOSAppLocation.appRunningModalDialog.message',
+            { productName }
+          ),
           buttons: [
-            'OK'
+            i18next.t('common.enforceMacOSAppLocation.appRunningModalDialog.confirmButtonText')
           ]
         })
 


### PR DESCRIPTION
This PR adds translation support to the `enforce-macos-app-location` module

---

![Screenshot 2024-11-08 at 12 38 04](https://github.com/user-attachments/assets/a979e9b6-cb76-45ec-9f41-f23e73f2e823)

![Screenshot 2024-11-08 at 12 40 02](https://github.com/user-attachments/assets/7f3a381b-cd61-4822-b755-50a3c5097c8d)

