### PR TITLE
Add translation support to export-db module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -126,6 +126,10 @@
         "message": "Another version of {{productName}} is currently running. Quit it, then launch this version of the app again",
         "confirmButtonText": "OK"
       }
+    },
+    "showMessageModalDialog": {
+      "confirmButtonText": "OK",
+      "cancelButtonText": "Cancel"
     }
   },
   "menu": {

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -130,6 +130,18 @@
     "showMessageModalDialog": {
       "confirmButtonText": "OK",
       "cancelButtonText": "Cancel"
+    },
+    "showErrorModalDialog": {
+      "confirmButtonText": "OK",
+      "enoentErrorMessage": "No such file or directory",
+      "eaccesErrorMessage": "Permission denied",
+      "invalidFilePathErrorMessage": "Invalid file path",
+      "invalidFileNameInArchErrorMessage": "Invalid file name in archive",
+      "dbImportingErrorMessage": "The database has not been imported",
+      "dbRemovingErrorMessage": "The database has not been removed",
+      "reportsFolderChangingErrorMessage": "The reports folder has not been changed",
+      "syncFrequencyChangingErrorMessage": "The sync frequency has not been changed",
+      "unexpectedExceptionMessage": "An unexpected exception occurred"
     }
   },
   "menu": {

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -142,6 +142,17 @@
       "reportsFolderChangingErrorMessage": "The reports folder has not been changed",
       "syncFrequencyChangingErrorMessage": "The sync frequency has not been changed",
       "unexpectedExceptionMessage": "An unexpected exception occurred"
+    },
+    "exportDB": {
+      "saveDialog": {
+        "title": "Database export",
+        "buttonLabel": "Export"
+      },
+      "modalDialog": {
+        "confirmButtonText": "OK",
+        "title": "Database export",
+        "message": "Exported successfully"
+      }
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -126,6 +126,10 @@
         "message": "В настоящее время запущена другая версия {{productName}}. Закройте ее, затем снова запустите эту версию приложения",
         "confirmButtonText": "OK"
       }
+    },
+    "showMessageModalDialog": {
+      "confirmButtonText": "OK",
+      "cancelButtonText": "Отмена"
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -130,6 +130,18 @@
     "showMessageModalDialog": {
       "confirmButtonText": "OK",
       "cancelButtonText": "Отмена"
+    },
+    "showErrorModalDialog": {
+      "confirmButtonText": "OK",
+      "enoentErrorMessage": "Данный файл или каталог отсутствует",
+      "eaccesErrorMessage": "Доступ запрещен",
+      "invalidFilePathErrorMessage": "Неверный путь к файлу",
+      "invalidFileNameInArchErrorMessage": "Неверное имя файла в архиве",
+      "dbImportingErrorMessage": "База данных не была импортирована",
+      "dbRemovingErrorMessage": "База данных не была удалена",
+      "reportsFolderChangingErrorMessage": "Папка отчетов не была изменена",
+      "syncFrequencyChangingErrorMessage": "Частота синхронизации не была изменена",
+      "unexpectedExceptionMessage": "Произошло неожиданное исключение"
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -142,6 +142,17 @@
       "reportsFolderChangingErrorMessage": "Папка отчетов не была изменена",
       "syncFrequencyChangingErrorMessage": "Частота синхронизации не была изменена",
       "unexpectedExceptionMessage": "Произошло неожиданное исключение"
+    },
+    "exportDB": {
+      "saveDialog": {
+        "title": "Экспорт базы данных",
+        "buttonLabel": "Экспортировать"
+      },
+      "modalDialog": {
+        "confirmButtonText": "OK",
+        "title": "Экспорт базы данных",
+        "message": "Экспортирована успешно"
+      }
     }
   },
   "menu": {

--- a/src/export-db.js
+++ b/src/export-db.js
@@ -11,6 +11,8 @@ const {
   showLoadingWindow,
   hideLoadingWindow
 } = require('./window-creators/change-loading-win-visibility-state')
+const wins = require('./window-creators/windows')
+const isMainWinAvailable = require('./helpers/is-main-win-available')
 const {
   DEFAULT_ARCHIVE_DB_FILE_NAME,
   DB_FILE_NAME,
@@ -35,7 +37,9 @@ module.exports = ({
   const secretKeyPath = path.join(pathToUserData, SECRET_KEY_FILE_NAME)
 
   return async () => {
-    const win = BrowserWindow.getFocusedWindow()
+    const win = isMainWinAvailable(wins.mainWindow)
+      ? wins.mainWindow
+      : BrowserWindow.getFocusedWindow()
 
     try {
       const {

--- a/src/export-db.js
+++ b/src/export-db.js
@@ -2,6 +2,7 @@
 
 const path = require('path')
 const { dialog, BrowserWindow } = require('electron')
+const i18next = require('i18next')
 
 const { InvalidFilePathError } = require('./errors')
 const { zip } = require('./archiver')
@@ -48,9 +49,10 @@ module.exports = ({
       } = await dialog.showSaveDialog(
         win,
         {
-          title: 'Database export',
+          title: i18next.t('common.exportDB.saveDialog.title'),
           defaultPath,
-          buttonLabel: 'Export',
+          buttonLabel: i18next
+            .t('common.exportDB.saveDialog.buttonLabel'),
           filters: [{ name: 'ZIP', extensions: ['zip'] }]
         }
       )
@@ -75,15 +77,21 @@ module.exports = ({
       await hideLoadingWindow()
 
       await showMessageModalDialog(win, {
-        buttons: ['OK'],
+        buttons: [
+          i18next.t('common.exportDB.modalDialog.confirmButtonText')
+        ],
         defaultId: 0,
-        title: 'Database export',
-        message: 'Exported successfully'
+        title: i18next.t('common.exportDB.modalDialog.title'),
+        message: i18next.t('common.exportDB.modalDialog.message')
       })
     } catch (err) {
       try {
         await hideLoadingWindow()
-        await showErrorModalDialog(win, 'Database export', err)
+        await showErrorModalDialog(
+          win,
+          i18next.t('common.exportDB.modalDialog.title'),
+          err
+        )
       } catch (err) {
         console.error(err)
       }

--- a/src/show-error-modal-dialog.js
+++ b/src/show-error-modal-dialog.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const i18next = require('i18next')
+
 const {
   InvalidFilePathError,
   InvalidFileNameInArchiveError,
@@ -14,7 +16,9 @@ const showMessageModalDialog = require('./show-message-modal-dialog')
 const _showErrorBox = (win, title = '', message = '') => {
   return showMessageModalDialog(win, {
     type: 'error',
-    buttons: ['OK'],
+    buttons: [
+      i18next.t('common.showErrorModalDialog.confirmButtonText')
+    ],
     defaultId: 0,
     cancelId: 0,
     title,
@@ -24,7 +28,7 @@ const _showErrorBox = (win, title = '', message = '') => {
 
 module.exports = async (win, title = 'Error', err) => {
   if (err.code === 'ENOENT') {
-    const message = 'No such file or directory'
+    const message = i18next.t('common.showErrorModalDialog.enoentErrorMessage')
     const content = (err.syscall && err.path)
       ? `${message}, ${err.syscall}: '${err.path}'`
       : message
@@ -32,7 +36,7 @@ module.exports = async (win, title = 'Error', err) => {
     return _showErrorBox(win, title, content)
   }
   if (err.code === 'EACCES') {
-    const message = 'Permission denied'
+    const message = i18next.t('common.showErrorModalDialog.eaccesErrorMessage')
     const content = (err.syscall && err.path)
       ? `${message}, ${err.syscall}: '${err.path}'`
       : message
@@ -40,12 +44,12 @@ module.exports = async (win, title = 'Error', err) => {
     return _showErrorBox(win, title, content)
   }
   if (err instanceof InvalidFilePathError) {
-    const message = 'Invalid file path'
+    const message = i18next.t('common.showErrorModalDialog.invalidFilePathErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
   if (err instanceof InvalidFileNameInArchiveError) {
-    const message = 'Invalid file name in archive'
+    const message = i18next.t('common.showErrorModalDialog.invalidFileNameInArchErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
@@ -53,27 +57,27 @@ module.exports = async (win, title = 'Error', err) => {
     err instanceof DbImportingError ||
     err instanceof InvalidFolderPathError
   ) {
-    const message = 'The database has not been imported'
+    const message = i18next.t('common.showErrorModalDialog.dbImportingErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
   if (err instanceof DbRemovingError) {
-    const message = 'The database has not been removed'
+    const message = i18next.t('common.showErrorModalDialog.dbRemovingErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
   if (err instanceof ReportsFolderChangingError) {
-    const message = 'The reports folder has not been changed'
+    const message = i18next.t('common.showErrorModalDialog.reportsFolderChangingErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
   if (err instanceof SyncFrequencyChangingError) {
-    const message = 'The sync frequency has not been changed'
+    const message = i18next.t('common.showErrorModalDialog.syncFrequencyChangingErrorMessage')
 
     return _showErrorBox(win, title, message)
   }
 
-  const message = 'An unexpected exception occurred'
+  const message = i18next.t('common.showErrorModalDialog.syncFrequencyChangingErrorMessage')
 
   return _showErrorBox(win, title, message)
 }

--- a/src/show-message-modal-dialog.js
+++ b/src/show-message-modal-dialog.js
@@ -2,15 +2,21 @@
 
 const { dialog, BrowserWindow } = require('electron')
 
+const wins = require('./window-creators/windows')
+const isMainWinAvailable = require('./helpers/is-main-win-available')
+
 module.exports = async (win, opts = {}) => {
-  const _win = win && typeof win === 'object'
-    ? win
+  const defaultWin = isMainWinAvailable(wins.mainWindow)
+    ? wins.mainWindow
     : BrowserWindow.getFocusedWindow()
+  const parentWin = win && typeof win === 'object'
+    ? win
+    : defaultWin
 
   const {
     response: btnId,
     checkboxChecked
-  } = await dialog.showMessageBox(_win, {
+  } = await dialog.showMessageBox(parentWin, {
     type: 'info',
     buttons: ['Cancel', 'OK'],
     defaultId: 1,

--- a/src/show-message-modal-dialog.js
+++ b/src/show-message-modal-dialog.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { dialog, BrowserWindow } = require('electron')
+const i18next = require('i18next')
 
 const wins = require('./window-creators/windows')
 const isMainWinAvailable = require('./helpers/is-main-win-available')
@@ -18,7 +19,10 @@ module.exports = async (win, opts = {}) => {
     checkboxChecked
   } = await dialog.showMessageBox(parentWin, {
     type: 'info',
-    buttons: ['Cancel', 'OK'],
+    buttons: [
+      i18next.t('common.showMessageModalDialog.cancelButtonText'),
+      i18next.t('common.showMessageModalDialog.confirmButtonText')
+    ],
     defaultId: 1,
     cancelId: 0,
     title: '',


### PR DESCRIPTION
This PR adds translation support to the `export-db` module

---

![Screenshot from 2024-11-12 12-04-44](https://github.com/user-attachments/assets/1fe7f206-89d0-4748-a08e-f5f36729c18a)

![Screenshot from 2024-11-12 12-11-40](https://github.com/user-attachments/assets/82894fc4-1924-473a-893e-6b3009666724)


