### PR TITLE
Add progress perc to loading window for export-db module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -152,6 +152,10 @@
         "confirmButtonText": "OK",
         "title": "Database export",
         "message": "Exported successfully"
+      },
+      "loadingWindow": {
+        "description": "Exporting DB ...",
+        "archiveSize": "archive size {{prettyArchiveSize}}"
       }
     },
     "importDB": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -152,6 +152,10 @@
         "confirmButtonText": "OK",
         "title": "Экспорт базы данных",
         "message": "Экспортирована успешно"
+      },
+      "loadingWindow": {
+        "description": "Экспортирование БД ...",
+        "archiveSize": "размер архива {{prettyArchiveSize}}"
       }
     },
     "importDB": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "archiver": "5.3.0",
+    "archiver": "7.0.1",
     "bfx-svc-test-helper": "git+https://github.com/bitfinexcom/bfx-svc-test-helper.git",
     "bittorrent-dht": "10.0.2",
     "changelog-parser": "3.0.1",

--- a/src/show-error-modal-dialog.js
+++ b/src/show-error-modal-dialog.js
@@ -77,7 +77,7 @@ module.exports = async (win, title = 'Error', err) => {
     return _showErrorBox(win, title, message)
   }
 
-  const message = i18next.t('common.showErrorModalDialog.syncFrequencyChangingErrorMessage')
+  const message = i18next.t('common.showErrorModalDialog.unexpectedExceptionMessage')
 
   return _showErrorBox(win, title, message)
 }


### PR DESCRIPTION
This PR adds `progress` perc to the loading window for the `export db` module as it can take significant time for large DB

---

The `archiver` lib has a `progress` event available: https://www.archiverjs.com/docs/archiver#event-progress
But this event emits once for each file processed
As we can have large DB files it won't be useful and informative
And to show users that the process is going well adds showing creating archive bytes size, the size refreshes every `3sec`

---

- `en`:
![Screenshot from 2024-11-13 20-35-33](https://github.com/user-attachments/assets/afac8bb8-a9bc-4adf-a336-acfa32d2aed4)
![Screenshot from 2024-11-13 20-37-31](https://github.com/user-attachments/assets/4b78241d-83d4-4afe-b225-71cb9f2900bf)
![Screenshot from 2024-11-13 20-38-43](https://github.com/user-attachments/assets/337b335d-5d42-4533-87b5-a8c3c578cebf)

- `ru`:
![Screenshot from 2024-11-13 15-01-25](https://github.com/user-attachments/assets/91f2919a-786e-4828-b509-6b768b6ff8ac)
![Screenshot from 2024-11-13 15-03-07](https://github.com/user-attachments/assets/39ec9c18-6b15-48ad-99d8-64f03fa24156)
![Screenshot from 2024-11-13 15-06-01](https://github.com/user-attachments/assets/be13d8b1-b342-43c4-be2e-1781adda3345)


