### PR TITLE
Add progress perc to loading win for import-db module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -165,6 +165,10 @@
       },
       "modalDialog": {
         "title": "Database import"
+      },
+      "loadingWindow": {
+        "description": "Importing DB ...",
+        "unzippedBytes": "DB size {{prettyUnzippedBytes}}"
       }
     }
   },

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -165,6 +165,10 @@
       },
       "modalDialog": {
         "title": "Импорт базы данных"
+      },
+      "loadingWindow": {
+        "description": "Импортирование БД ...",
+        "unzippedBytes": "размер БД {{prettyUnzippedBytes}}"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "new-github-issue-url": "0.2.1",
     "showdown": "2.0.3",
     "truncate-utf8-bytes": "1.0.2",
-    "yauzl": "2.10.0"
+    "yauzl": "3.2.0"
   },
   "devDependencies": {
     "@mapbox/node-pre-gyp": "1.0.11",

--- a/src/pause-app.js
+++ b/src/pause-app.js
@@ -28,12 +28,16 @@ const _closeServer = () => {
   })
 }
 
-module.exports = async (opts = {}) => {
+module.exports = async (opts) => {
   const {
-    beforeClosingServHook = () => {}
-  } = opts
+    beforeClosingServHook = () => {},
+    loadingWinParams
+  } = opts ?? {}
 
-  await showLoadingWindow({ isRequiredToCloseAllWins: true })
+  await showLoadingWindow({
+    isRequiredToCloseAllWins: true,
+    ...loadingWinParams
+  })
 
   await beforeClosingServHook()
 


### PR DESCRIPTION
This PR adds `progress` perc to the loading window for the `import-db` module as it can take significant time for large DB

---

There is no `progress` event available in the `yauzl` lib
We have to handle progress by getting data chunk length for each file stream

---

- en:
![en-1](https://github.com/user-attachments/assets/d1613891-a501-4a79-bf5c-d8f6e0d6a904)
![en-2](https://github.com/user-attachments/assets/f7b19f7e-3d83-41a7-90cd-b05a12af3788)
![en-3](https://github.com/user-attachments/assets/c58566d2-1f4c-4c50-a695-fc9cb029855c)

- ru:
![ru-1](https://github.com/user-attachments/assets/e25ce3f8-478b-4820-87ba-29e1cb142eb1)
![ru-2](https://github.com/user-attachments/assets/0c05ca5e-2abf-486b-ba9d-dad46854e0f5)
![ru-3](https://github.com/user-attachments/assets/f34a6c96-86b9-4fcc-8a50-9918dc6ef295)
