### PR TITLE
Add translation support to remove-db module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -178,6 +178,16 @@
         "clearDataMessage": "Are you sure you want to clear all data?",
         "removeDBMessage": "Are you sure you want to remove the database?"
       },
+      "messageModalDialog": {
+        "dbRemovingTitle": "DB removing",
+        "dbDataHasBeenRemovedMessage": "DB data has been removed",
+        "dbDataHasNotBeenRemovedMessage": "DB data has not been removed",
+        "dbHasNotBeenRestoredTitle": "DB has not been restored",
+        "removeDBTitle": "Remove database",
+        "removeDBMessage": "Should all tables be removed?",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Cancel"
+      },
       "loadingWindow": {
         "description": "Removing DB ..."
       }

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -170,6 +170,17 @@
         "description": "Importing DB ...",
         "unzippedBytes": "DB size {{prettyUnzippedBytes}}"
       }
+    },
+    "removeDB": {
+      "modalDialog": {
+        "clearDataTitle": "Clear all data",
+        "removeDBTitle": "Remove database",
+        "clearDataMessage": "Are you sure you want to clear all data?",
+        "removeDBMessage": "Are you sure you want to remove the database?"
+      },
+      "loadingWindow": {
+        "description": "Removing DB ..."
+      }
     }
   },
   "menu": {

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -189,7 +189,8 @@
         "cancelButtonText": "Cancel"
       },
       "loadingWindow": {
-        "description": "Removing DB ..."
+        "removingDBDescription": "Removing DB ...",
+        "clearingAllDataDescription": "Clearing all data ..."
       }
     }
   },

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -178,6 +178,16 @@
         "clearDataMessage": "Вы уверены, что хотите удалить все данные?",
         "removeDBMessage": "Вы уверены, что хотите удалить базу данных?"
       },
+      "messageModalDialog": {
+        "dbRemovingTitle": "Удаление БД",
+        "dbDataHasBeenRemovedMessage": "Данные БД были удалены",
+        "dbDataHasNotBeenRemovedMessage": "Данные БД не были удалены",
+        "dbHasNotBeenRestoredTitle": "БД не восстановлена",
+        "removeDBTitle": "Удалить базу данных",
+        "removeDBMessage": "Следует ли удалить все таблицы?",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Отмена"
+      },
       "loadingWindow": {
         "description": "Удаление БД ..."
       }

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -189,7 +189,8 @@
         "cancelButtonText": "Отмена"
       },
       "loadingWindow": {
-        "description": "Удаление БД ..."
+        "removingDBDescription": "Удаление БД ...",
+        "clearingAllDataDescription": "Очистка всех данные ..."
       }
     }
   },

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -170,6 +170,17 @@
         "description": "Импортирование БД ...",
         "unzippedBytes": "размер БД {{prettyUnzippedBytes}}"
       }
+    },
+    "removeDB": {
+      "modalDialog": {
+        "clearDataTitle": "Очистить все данные",
+        "removeDBTitle": "Удалить базу данных",
+        "clearDataMessage": "Вы уверены, что хотите удалить все данные?",
+        "removeDBMessage": "Вы уверены, что хотите удалить базу данных?"
+      },
+      "loadingWindow": {
+        "description": "Удаление БД ..."
+      }
     }
   },
   "menu": {

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -93,18 +93,20 @@ module.exports = (ipc) => {
         await showWindow(win)
 
         const haveNotAllDbDataBeenRemoved = state === PROCESS_MESSAGES.ALL_TABLE_HAVE_NOT_BEEN_REMOVED
-        const messChunk = haveNotAllDbDataBeenRemoved
-          ? ' not'
-          : ''
+        const message = haveNotAllDbDataBeenRemoved
+          ? i18next.t('common.removeDB.messageModalDialog.dbDataHasNotBeenRemovedMessage')
+          : i18next.t('common.removeDB.messageModalDialog.dbDataHasBeenRemovedMessage')
         const type = haveNotAllDbDataBeenRemoved
           ? 'error'
           : 'info'
 
         await showMessageModalDialog(win, {
           type,
-          title: 'DB removing',
-          message: `DB data have${messChunk} been removed`,
-          buttons: ['OK'],
+          title: i18next.t('common.removeDB.messageModalDialog.dbRemovingTitle'),
+          message,
+          buttons: [
+            i18next.t('common.removeDB.messageModalDialog.confirmButtonText')
+          ],
           defaultId: 0,
           cancelId: 0
         })
@@ -219,16 +221,19 @@ module.exports = (ipc) => {
       }
       if (state === PROCESS_MESSAGES.REQUEST_SHOULD_ALL_TABLES_BE_REMOVED) {
         const title = data.isNotDbRestored
-          ? 'DB has not been restored'
-          : 'Remove database'
+          ? i18next.t('common.removeDB.messageModalDialog.dbHasNotBeenRestoredTitle')
+          : i18next.t('common.removeDB.messageModalDialog.removeDBTitle')
 
         const {
           btnId
         } = await showMessageModalDialog(win, {
           type: 'question',
           title,
-          message: 'Should all tables be removed?',
-          buttons: ['Cancel', 'OK']
+          message: i18next.t('common.removeDB.messageModalDialog.removeDBMessage'),
+          buttons: [
+            i18next.t('common.removeDB.messageModalDialog.cancelButtonText'),
+            i18next.t('common.removeDB.messageModalDialog.confirmButtonText')
+          ]
         })
 
         if (btnId === 0) {

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -92,11 +92,11 @@ module.exports = ({
       ? wins.mainWindow
       : BrowserWindow.getFocusedWindow()
     const title = shouldAllTablesBeCleared
-      ? 'Clear all data'
-      : 'Remove database'
+      ? i18next.t('common.removeDB.modalDialog.clearDataTitle')
+      : i18next.t('common.removeDB.modalDialog.removeDBTitle')
     const message = shouldAllTablesBeCleared
-      ? 'Are you sure you want to clear all data?'
-      : 'Are you sure you want to remove the database?'
+      ? i18next.t('common.removeDB.modalDialog.clearDataMessage')
+      : i18next.t('common.removeDB.modalDialog.removeDBMessage')
 
     try {
       const {

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -121,8 +121,9 @@ module.exports = ({
           await _clearAllTables()
         },
         loadingWinParams: {
-          description: i18next
-            .t('common.removeDB.loadingWindow.description')
+          description: shouldAllTablesBeCleared
+            ? i18next.t('common.removeDB.loadingWindow.clearingAllDataDescription')
+            : i18next.t('common.removeDB.loadingWindow.removingDBDescription')
         }
       })
 

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -1,10 +1,12 @@
 'use strict'
 
-const electron = require('electron')
+const { BrowserWindow } = require('electron')
 
 const ipcs = require('./ipcs')
 const showErrorModalDialog = require('./show-error-modal-dialog')
 const showMessageModalDialog = require('./show-message-modal-dialog')
+const wins = require('./window-creators/windows')
+const isMainWinAvailable = require('./helpers/is-main-win-available')
 const pauseApp = require('./pause-app')
 const relaunch = require('./relaunch')
 const { rm } = require('./helpers')
@@ -85,7 +87,9 @@ module.exports = ({
   shouldAllTablesBeCleared
 }) => {
   return async () => {
-    const win = electron.BrowserWindow.getFocusedWindow()
+    const win = isMainWinAvailable(wins.mainWindow)
+      ? wins.mainWindow
+      : BrowserWindow.getFocusedWindow()
     const title = shouldAllTablesBeCleared
       ? 'Clear all data'
       : 'Remove database'
@@ -124,7 +128,10 @@ module.exports = ({
       relaunch()
     } catch (err) {
       try {
-        await showErrorModalDialog(win, title, err)
+        const _win = isMainWinAvailable(wins.loadingWindow)
+          ? wins.loadingWindow
+          : win
+        await showErrorModalDialog(_win, title, err)
       } catch (err) {
         console.error(err)
       }

--- a/src/remove-db.js
+++ b/src/remove-db.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const { BrowserWindow } = require('electron')
+const i18next = require('i18next')
 
 const ipcs = require('./ipcs')
 const showErrorModalDialog = require('./show-error-modal-dialog')
@@ -118,6 +119,10 @@ module.exports = ({
           }
 
           await _clearAllTables()
+        },
+        loadingWinParams: {
+          description: i18next
+            .t('common.removeDB.loadingWindow.description')
         }
       })
 


### PR DESCRIPTION
This PR adds translation support to the `remove-db` module

---

- en:
![Screenshot from 2024-11-20 10-40-21](https://github.com/user-attachments/assets/33a46504-0a3c-4a5d-849e-a0f40589eaee)
![Screenshot from 2024-11-20 10-40-32](https://github.com/user-attachments/assets/05225145-a2c6-41e3-8b7f-e332085b9f3b)
![Screenshot from 2024-11-20 10-40-53](https://github.com/user-attachments/assets/90f54ea4-3bff-4dba-b034-5634935374a0)
![Screenshot from 2024-11-20 10-41-12](https://github.com/user-attachments/assets/5223c248-bc31-4c71-9c6b-7d75a136323e)

- ru:
![Screenshot from 2024-11-20 10-29-19](https://github.com/user-attachments/assets/930a3d74-3779-46df-8a55-ffd489b58351)
![Screenshot from 2024-11-20 10-32-28](https://github.com/user-attachments/assets/eb419054-f37c-42f9-9f6e-978141bd5771)
![Screenshot from 2024-11-20 10-32-57](https://github.com/user-attachments/assets/dd754106-40e9-4118-99ca-b07a4e069200)
![Screenshot from 2024-11-20 10-38-58](https://github.com/user-attachments/assets/e864751f-406b-4db9-8060-25000d5893c8)
