### PR TITLE
Add translation support to manage-worker-messages module

### DIFF
--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -201,7 +201,7 @@
     },
     "migrationDB": {
       "messageModalDialog": {
-        "dbMigrationHasFailedMessage": "DВ migration has failed, all data has been deleted,\nsynchronization will start from scratch",
+        "dbMigrationHasFailedMessage": "DВ migration has failed",
         "dbMigrationHasCompletedMessage": "DB migration has completed successfully",
         "confirmButtonText": "OK",
         "cancelButtonText": "Cancel"

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -195,9 +195,24 @@
     },
     "backupDB": {
       "backupDBTitle": "DB backup",
-      "dbBackupHasBeenDone": "DB backup has been successfully",
-      "dbBackupHasNotBeenDone": "DB backup has not been successfully",
+      "dbBackupHasCompletedMessage": "DB backup has completed successfully",
+      "dbBackupHasFailedMessage": "DB backup has failed",
       "confirmButtonText": "OK"
+    },
+    "migrationDB": {
+      "messageModalDialog": {
+        "dbMigrationHasFailedMessage": "DВ migration has failed, all data has been deleted,\nsynchronization will start from scratch",
+        "dbMigrationHasCompletedMessage": "DB migration has completed successfully",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Cancel"
+      },
+      "actionRequestModalDialog": {
+        "title": "The migration has failed",
+        "message": "What should be done?",
+        "exitButtonText": "Exit",
+        "restoreDBButtonText": "Try to restore DB",
+        "removeDBButtonText": "Remove DB"
+      }
     }
   },
   "menu": {

--- a/build/locales/en/translations.json
+++ b/build/locales/en/translations.json
@@ -192,6 +192,12 @@
         "removingDBDescription": "Removing DB ...",
         "clearingAllDataDescription": "Clearing all data ..."
       }
+    },
+    "backupDB": {
+      "backupDBTitle": "DB backup",
+      "dbBackupHasBeenDone": "DB backup has been successfully",
+      "dbBackupHasNotBeenDone": "DB backup has not been successfully",
+      "confirmButtonText": "OK"
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -192,6 +192,12 @@
         "removingDBDescription": "Удаление БД ...",
         "clearingAllDataDescription": "Очистка всех данные ..."
       }
+    },
+    "backupDB": {
+      "backupDBTitle": "Резервное копирование БД",
+      "dbBackupHasBeenDone": "Резервное копирование БД успешно завершено",
+      "dbBackupHasNotBeenDone": "Резервное копирование БД не было успешно выполнено",
+      "confirmButtonText": "OK"
     }
   },
   "menu": {

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -201,7 +201,7 @@
     },
     "migrationDB": {
       "messageModalDialog": {
-        "dbMigrationHasFailedMessage": "Миграция БД не удалась, все данные удалены,\nсинхронизация начнется с нуля",
+        "dbMigrationHasFailedMessage": "Миграция БД не удалась",
         "dbMigrationHasCompletedMessage": "Миграция БД успешно завершена",
         "confirmButtonText": "OK",
         "cancelButtonText": "Отмена"

--- a/build/locales/ru/translations.json
+++ b/build/locales/ru/translations.json
@@ -195,9 +195,24 @@
     },
     "backupDB": {
       "backupDBTitle": "Резервное копирование БД",
-      "dbBackupHasBeenDone": "Резервное копирование БД успешно завершено",
-      "dbBackupHasNotBeenDone": "Резервное копирование БД не было успешно выполнено",
+      "dbBackupHasCompletedMessage": "Резервное копирование БД успешно завершено",
+      "dbBackupHasFailedMessage": "Резервное копирование БД не удалось",
       "confirmButtonText": "OK"
+    },
+    "migrationDB": {
+      "messageModalDialog": {
+        "dbMigrationHasFailedMessage": "Миграция БД не удалась, все данные удалены,\nсинхронизация начнется с нуля",
+        "dbMigrationHasCompletedMessage": "Миграция БД успешно завершена",
+        "confirmButtonText": "OK",
+        "cancelButtonText": "Отмена"
+      },
+      "actionRequestModalDialog": {
+        "title": "Миграция не удалась",
+        "message": "Что следует сделать?",
+        "exitButtonText": "Выход",
+        "restoreDBButtonText": "Попробовать восстановить БД",
+        "removeDBButtonText": "Удалить БД"
+      }
     }
   },
   "menu": {

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -121,8 +121,8 @@ module.exports = (ipc) => {
 
         const isBackupError = state === PROCESS_MESSAGES.ERROR_BACKUP
         const message = isBackupError
-          ? i18next.t('common.backupDB.dbBackupHasNotBeenDone')
-          : i18next.t('common.backupDB.dbBackupHasBeenDone')
+          ? i18next.t('common.backupDB.dbBackupHasFailedMessage')
+          : i18next.t('common.backupDB.dbBackupHasCompletedMessage')
         const type = isBackupError
           ? 'error'
           : 'info'
@@ -178,12 +178,12 @@ module.exports = (ipc) => {
         const type = isMigrationsError
           ? 'error'
           : 'info'
-        const message = isMigrationsError // TODO:
-          ? 'DВ migration failed, all data has been deleted,\nsynchronization will start from scratch'
-          : 'DB migration completed successfully'
+        const message = isMigrationsError
+          ? i18next.t('common.migrationDB.messageModalDialog.dbMigrationHasFailedMessage')
+          : i18next.t('common.migrationDB.messageModalDialog.dbMigrationHasCompletedMessage')
         const buttons = isMigrationsError
-          ? ['Cancel'] // TODO:
-          : ['OK'] // TODO:
+          ? [i18next.t('common.migrationDB.messageModalDialog.cancelButtonText')]
+          : [i18next.t('common.migrationDB.messageModalDialog.confirmButtonText')]
 
         await showMessageModalDialog(win, {
           type,
@@ -200,9 +200,15 @@ module.exports = (ipc) => {
           btnId
         } = await showMessageModalDialog(win, {
           type: 'question',
-          title: 'The migration has failed', // TODO:
-          message: 'What should be done?', // TODO:
-          buttons: ['Exit', 'Try to restore DB', 'Remove DB'] // TODO:
+          title: i18next
+            .t('common.migrationDB.actionRequestModalDialog.title'),
+          message: i18next
+            .t('common.migrationDB.actionRequestModalDialog.message'),
+          buttons: [
+            i18next.t('common.migrationDB.actionRequestModalDialog.exitButtonText'),
+            i18next.t('common.migrationDB.actionRequestModalDialog.restoreDBButtonText'),
+            i18next.t('common.migrationDB.actionRequestModalDialog.removeDBButtonText')
+          ]
         })
 
         if (btnId === 0) {

--- a/src/manage-worker-messages.js
+++ b/src/manage-worker-messages.js
@@ -120,18 +120,20 @@ module.exports = (ipc) => {
         await showWindow(win)
 
         const isBackupError = state === PROCESS_MESSAGES.ERROR_BACKUP
-        const messChunk = isBackupError
-          ? ' not'
-          : ''
+        const message = isBackupError
+          ? i18next.t('common.backupDB.dbBackupHasNotBeenDone')
+          : i18next.t('common.backupDB.dbBackupHasBeenDone')
         const type = isBackupError
           ? 'error'
           : 'info'
 
         await showMessageModalDialog(win, {
           type,
-          title: 'DB backup',
-          message: `DB backup has${messChunk} been successfully`,
-          buttons: ['OK'],
+          title: i18next.t('common.backupDB.backupDBTitle'),
+          message,
+          buttons: [
+            i18next.t('common.backupDB.confirmButtonText')
+          ],
           defaultId: 0,
           cancelId: 0
         })
@@ -176,12 +178,12 @@ module.exports = (ipc) => {
         const type = isMigrationsError
           ? 'error'
           : 'info'
-        const message = isMigrationsError
+        const message = isMigrationsError // TODO:
           ? 'DВ migration failed, all data has been deleted,\nsynchronization will start from scratch'
           : 'DB migration completed successfully'
         const buttons = isMigrationsError
-          ? ['Cancel']
-          : ['OK']
+          ? ['Cancel'] // TODO:
+          : ['OK'] // TODO:
 
         await showMessageModalDialog(win, {
           type,
@@ -198,9 +200,9 @@ module.exports = (ipc) => {
           btnId
         } = await showMessageModalDialog(win, {
           type: 'question',
-          title: 'The migration has failed',
-          message: 'What should be done?',
-          buttons: ['Exit', 'Try to restore DB', 'Remove DB']
+          title: 'The migration has failed', // TODO:
+          message: 'What should be done?', // TODO:
+          buttons: ['Exit', 'Try to restore DB', 'Remove DB'] // TODO:
         })
 
         if (btnId === 0) {

--- a/src/show-message-modal-dialog.js
+++ b/src/show-message-modal-dialog.js
@@ -5,6 +5,9 @@ const i18next = require('i18next')
 
 const wins = require('./window-creators/windows')
 const isMainWinAvailable = require('./helpers/is-main-win-available')
+const {
+  showWindow
+} = require('./helpers/manage-window')
 
 module.exports = async (win, opts = {}) => {
   const defaultWin = isMainWinAvailable(wins.mainWindow)
@@ -13,6 +16,10 @@ module.exports = async (win, opts = {}) => {
   const parentWin = win && typeof win === 'object'
     ? win
     : defaultWin
+
+  if (opts?.shouldParentWindowBeShown) {
+    await showWindow(win)
+  }
 
   const {
     response: btnId,


### PR DESCRIPTION
This PR adds translation support to the `manage-worker-messages` module

---

Basic changes:
- Adds translation support to `backup-db`
- Add translation support to `migration-db`
- Fixes showing modal dialogs in sequence

---

- `en`:
![Screenshot from 2024-11-22 07-46-45](https://github.com/user-attachments/assets/760a9235-2593-445d-8e38-804cdcdf35e6)
![Screenshot from 2024-11-22 07-47-05](https://github.com/user-attachments/assets/25935b3f-b45a-42b1-9d8c-3ea682be4495)
![Screenshot from 2024-11-22 07-47-24](https://github.com/user-attachments/assets/36e1e128-613e-47b9-9874-1ae50a46ed0c)

- `ru`:
![Screenshot from 2024-11-22 07-48-21](https://github.com/user-attachments/assets/1bfb684a-0de2-4313-85ba-6f3a142e48da)
![Screenshot from 2024-11-22 07-48-42](https://github.com/user-attachments/assets/50449399-904d-4e23-ae8c-e930343285a3)
![Screenshot from 2024-11-22 07-49-13](https://github.com/user-attachments/assets/a6272592-2053-48be-9255-2ff0b95e1bc7)
