### PR TITLE
Fix docker desktop container user permissions breaks

### DIFF
--- a/Dockerfile.linux-builder
+++ b/Dockerfile.linux-builder
@@ -14,7 +14,6 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.mac-builder
+++ b/Dockerfile.mac-builder
@@ -14,7 +14,6 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.ui-builder
+++ b/Dockerfile.ui-builder
@@ -8,7 +8,6 @@ ENV IS_DEV_ENV=${IS_DEV_ENV:-0}
 COPY ./scripts/helpers/install-nodejs.sh ./scripts/helpers/install-nodejs.sh
 
 RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION}
-RUN chown root:root .
 
 COPY . .
 

--- a/Dockerfile.win-builder
+++ b/Dockerfile.win-builder
@@ -17,7 +17,6 @@ RUN ./scripts/helpers/install-nodejs.sh ${NODE_VERSION} \
     bc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
-RUN chown root:root .
 
 COPY . .
 


### PR DESCRIPTION
This PR fixes docker desktop container user permissions breaks
Fixes chown: `changing ownership of 'path-to-file': Operation not permitted` when using it in `dockerfile`
The context here:
- https://github.com/docker/desktop-linux/issues/252#issuecomment-2436547195
- https://github.com/docker/desktop-linux/issues/9

---

![Screenshot from 2024-11-22 14-13-58](https://github.com/user-attachments/assets/cc72ca5a-54eb-4d65-8209-a30ee840e37c)

---

The workflow has been tested:
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/12006345135
- https://github.com/ZIMkaRU/bfx-report-electron/releases/tag/v4.31.0-beta.2

