### PR TITLE
Change layout font family to prevent throwing error

### DIFF
--- a/src/auto-updater/toast-src/toast.css
+++ b/src/auto-updater/toast-src/toast.css
@@ -1,5 +1,6 @@
 body .swal2-container {
-  font-family: "Roboto", sans-serif;
+  font-family: "Inter", sans-serif;
+  font-feature-settings: 'tnum';
   margin: 0;
 }
 

--- a/src/helpers/get-ui-fonts-as-css-string.js
+++ b/src/helpers/get-ui-fonts-as-css-string.js
@@ -6,12 +6,12 @@ const path = require('path')
 
 const fontsPath = path.join(rootPath, 'bfx-report-ui/build/fonts/')
 const fontsStyle = fs.readFileSync(
-  path.join(fontsPath, 'roboto.css'),
+  path.join(fontsPath, 'inter.css'),
   'utf8'
 )
 const fStyleWithNormalizedPaths = fontsStyle.replace(
-  /url\(\.\/(.*\..*)\)/g,
-  `url(${fontsPath}$1)`
+  /url\('\.\/(.*\..*)'\)/g,
+  `url('${fontsPath}$1')`
 )
 
 module.exports = () => fStyleWithNormalizedPaths

--- a/src/modal-dialog-src/modal-dialog.css
+++ b/src/modal-dialog-src/modal-dialog.css
@@ -1,5 +1,6 @@
 body .swal2-container {
-  font-family: "Roboto", sans-serif;
+  font-family: "Inter", sans-serif;
+  font-feature-settings: 'tnum';
 }
 
 body::-webkit-scrollbar,

--- a/src/window-creators/layouts/app-init-error.html
+++ b/src/window-creators/layouts/app-init-error.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="shortcut icon" href="../../../bfx-report-ui/build/favicon.ico">
-    <link href="../../../bfx-report-ui/build/fonts/roboto.css" rel="stylesheet">
+    <link href="../../../bfx-report-ui/build/fonts/inter.css" rel="stylesheet">
     <title>Bitfinex Reports</title>
     <style>
       html {
@@ -20,7 +20,8 @@
         justify-content: center;
         text-align: center;
         background-color: #172d3e;
-        font-family: "Roboto", sans-serif;
+        font-family: "Inter", sans-serif;
+        font-feature-settings: 'tnum';
       }
 
       .alert {

--- a/src/window-creators/layouts/app-init.html
+++ b/src/window-creators/layouts/app-init.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <link rel="shortcut icon" href="../../../bfx-report-ui/build/favicon.ico">
-  <link href="../../../bfx-report-ui/build/fonts/roboto.css" rel="stylesheet">
+  <link href="../../../bfx-report-ui/build/fonts/inter.css" rel="stylesheet">
   <title>Bitfinex Reports</title>
   <style>
     html {
@@ -19,7 +19,8 @@
       margin: 0;
       text-align: center;
       background-color: #172d3e;
-        font-family: "Roboto", sans-serif;
+      font-family: "Inter", sans-serif;
+      font-feature-settings: 'tnum';
     }
 
     .win-control-btn {


### PR DESCRIPTION
This PR changes the font family from `Roboto` to `Inter` to prevent throwing error due to the last UI changes (electron layouts use font source from the UI sub-module)

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report-ui/pull/896
