### PR TITLE
Increase app initialization timeout

### DIFF
--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -90,7 +90,7 @@ const _ipcMessToPromise = (ipc) => {
       const timeout = setTimeout(() => {
         rmHandler()
         reject(new AppInitializationError())
-      }, 10 * 60 * 1000).unref()
+      }, 30 * 60 * 1000).unref()
 
       const rmHandler = () => {
         ipc.off('message', handler)


### PR DESCRIPTION
This PR increases app initialization timeout to `30min` to be able to execute sqlite `vacuum` command on launch

---

**Depends** on this PR:
- https://github.com/bitfinexcom/bfx-report-electron/pull/514
