### PR TITLE
Update grenache deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14540,9 +14540,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
-      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.9.tgz",
+      "integrity": "sha512-XF4w9Xp+ZQgifKakjZYmFdkLoSWd34VGKcsTCwlNWM7QG3ZbaxnTsaBwnjFZqHRf/rROxaR8rXnbtwdvaDI+lA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
This PR updates `Grenache` dependencies due to the last Grenache updates (removed unsupported `request` lib)

---

Basic changes:
- Updates `grenache-grape`
- Updates `lib-js-util-base`
- Updates `bfx-svc-test-helper`
- Fixes high severity vulnerabilities by `npm audit`

---

All changes have been tested in beta https://github.com/ZIMkaRU/bfx-report-electron/releases/tag/v4.36.2-beta.0 with the following required sub-module updates:
- Updates `bfx-report-express`, https://github.com/bitfinexcom/bfx-report-express/pull/49
- Updates `bfx-report`, https://github.com/bitfinexcom/bfx-report/pull/435
- Updates `bfx-reports-framework`, https://github.com/bitfinexcom/bfx-reports-framework/pull/462

