### PR TITLE
Show npm lib scripts output to foreground

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+foreground-scripts=true


### PR DESCRIPTION
This PR shows npm lib scripts output to foreground due to security reasons