### PR TITLE
Release version 4.38.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
 save-exact=true
-foreground-scripts=true
-ignore-scripts=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact=true
+foreground-scripts=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.38.0] - 2025-10-08
+
+### Added
+
+- Added `Summary Statistics` info into the `getSummaryByAsset` endpoint. PR: [bfx-reports-framework#485](https://github.com/bitfinexcom/bfx-reports-framework/pull/485)
+- Implemented the possibility to login via `__bfx_token` cookie from the main platform for the `Reports` web in production. PR: [bfx-report-ui#968](https://github.com/bitfinexcom/bfx-report-ui/pull/968)
+- Implemented auto-refreshing possibility for the currently opened report after the regular/scheduled synchronization for represented data actualization. PR: [bfx-report-ui#969](https://github.com/bitfinexcom/bfx-report-ui/pull/969)
+
+### Changed
+
+- Disabled `Account Balance` refresh button during initial synchronization to prevent report generation errors possibility. PR: [bfx-report-ui#967](https://github.com/bitfinexcom/bfx-report-ui/pull/967)
+- Removed ivoices-related logic due to the removal of the `payInvoiceList` endpoint from the BFX API. PR: [bfx-report-ui#970](https://github.com/bitfinexcom/bfx-report-ui/pull/970)
+
 ## [4.37.0] - 2025-09-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.37.0] - 2025-09-24
+
+### Added
+
+- Implemented `USDT0ARB`, `USDT0INK` and `USDT0OPX` support in the symbols filters. PR: [bfx-report-ui#958](https://github.com/bitfinexcom/bfx-report-ui/pull/958)
+- Added network to `Tether` ccy for movement export similar to the UI representation. Added a similar approach as on the UI side. PR: [bfx-report#446](https://github.com/bitfinexcom/bfx-report/pull/446)
+- Showed `mtsStarted` instead of `mtsUpdated` timestamp in the `Date` column of the `Movements` report. PR: [bfx-report-ui#960](https://github.com/bitfinexcom/bfx-report-ui/pull/960)
+- Added `created` and `updated` timestamp for movements export. PR: [bfx-report#448](https://github.com/bitfinexcom/bfx-report/pull/448)
+
+### Changed
+
+- Reworked and optimized `WalletSelector` in a more performant way. PR: [bfx-report-ui#955](https://github.com/bitfinexcom/bfx-report-ui/pull/955)
+- Reworked `SectionSwitch` in a more performant way and reduced redundant code. PR: [bfx-report-ui#956](https://github.com/bitfinexcom/bfx-report-ui/pull/956)
+- Removed the filter normalizer to speed up requests, as it is not being used. PRs: [bfx-report#445](https://github.com/bitfinexcom/bfx-report/pull/445), [bfx-reports-framework#473](https://github.com/bitfinexcom/bfx-reports-framework/pull/473)
+
+### Fixed
+
+- Hid the `Invoices` report due to unannounced removal of the `payInvoiceList` endpoint from the `BFX API`. PR: [bfx-report-ui#961](https://github.com/bitfinexcom/bfx-report-ui/pull/961)
+- Removed `payInvoiceList` endpoint support due to unannounced removal from the `BFX API`. PRs: [bfx-report#449](https://github.com/bitfinexcom/bfx-report/pull/449), [bfx-reports-framework#479](https://github.com/bitfinexcom/bfx-reports-framework/pull/479)
+
+### Security
+
+- Showed npm lib scripts output to the foreground due to security reasons, disabled npm lib scripts where it's possible. PRs: [bfx-report-express#51](https://github.com/bitfinexcom/bfx-report-express/pull/51), [bfx-report-ui#959](https://github.com/bitfinexcom/bfx-report-ui/pull/959), [bfx-report-electron#551](https://github.com/bitfinexcom/bfx-report-electron/pull/551), [bfx-report#447](https://github.com/bitfinexcom/bfx-report/pull/447), [bfx-reports-framework#478](https://github.com/bitfinexcom/bfx-reports-framework/pull/478)
+
 ## [4.36.4] - 2025-08-27
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bfx-report-electron",
-      "version": "4.37.0",
+      "version": "4.38.0",
       "license": "Apache-2.0",
       "dependencies": {
         "archiver": "7.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.36.4",
+  "version": "4.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bfx-report-electron",
-      "version": "4.36.4",
+      "version": "4.37.0",
       "license": "Apache-2.0",
       "dependencies": {
         "archiver": "7.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.36.4",
+  "version": "4.37.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-report-electron",
-  "version": "4.37.0",
+  "version": "4.38.0",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
   "description": "Reporting tool",
   "author": "bitfinex.com",


### PR DESCRIPTION
## [4.38.0] - 2025-10-08

### Added

- Added `Summary Statistics` info into the `getSummaryByAsset` endpoint. PR: [bfx-reports-framework#485](https://github.com/bitfinexcom/bfx-reports-framework/pull/485)
- Implemented the possibility to login via `__bfx_token` cookie from the main platform for the `Reports` web in production. PR: [bfx-report-ui#968](https://github.com/bitfinexcom/bfx-report-ui/pull/968)
- Implemented auto-refreshing possibility for the currently opened report after the regular/scheduled synchronization for represented data actualization. PR: [bfx-report-ui#969](https://github.com/bitfinexcom/bfx-report-ui/pull/969)

### Changed

- Disabled `Account Balance` refresh button during initial synchronization to prevent report generation errors possibility. PR: [bfx-report-ui#967](https://github.com/bitfinexcom/bfx-report-ui/pull/967)
- Removed ivoices-related logic due to the removal of the `payInvoiceList` endpoint from the BFX API. PR: [bfx-report-ui#970](https://github.com/bitfinexcom/bfx-report-ui/pull/970)
