### PR TITLE
Fix mac notarize config

### DIFF
--- a/electron-builder-config.js
+++ b/electron-builder-config.js
@@ -75,17 +75,6 @@ const appOutDirs = new Map()
 const isNotarize = parseEnvValToBool(process.env.NOTARIZE)
 const arch = process.env.ARCH ?? 'x64'
 
-// Notarize can be done only on MacOS
-const macNotarize = (
-  process.platform === 'darwin' &&
-  isNotarize
-)
-  ? {
-      notarize: {
-        teamId: process.env.APPLE_TEAM_ID
-      }
-    }
-  : {}
 // DMG can be built only on MacOS
 const macSpecificTargets = process.platform === 'darwin'
   ? ['dmg', 'zip']
@@ -179,7 +168,10 @@ module.exports = {
     category: 'public.app-category.finance',
     minimumSystemVersion: '11',
     darkModeSupport: true,
-    ...macNotarize,
+    notarize: !!(
+      process.platform === 'darwin' &&
+      isNotarize
+    ),
     target: [
       'dir',
       ...macSpecificTargets


### PR DESCRIPTION
This PR fixes mac `notarize` config. The lib config schema was changed, and right now `notarize` must be a boolean

Sources:
- https://github.com/electron-userland/electron-builder/issues/7893
- https://www.electron.build/mac#notarize

Related to this build failure:
- https://github.com/bitfinexcom/bfx-report-electron/actions/runs/19566792672/job/56030633420
<img width="1416" height="767" alt="Screenshot from 2025-11-21 12-10-28" src="https://github.com/user-attachments/assets/8733add6-ac05-4feb-85dc-0a16f0fbe508" />

