### PR TITLE
Pass tag explicitly so that it is not replaced with hash

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -285,6 +285,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: draft.id,
+              tag_name: draft.tag_name || `v${version}`,
               body: content,
             })
   linux-e2e-test-runner:


### PR DESCRIPTION
This PR fixes the issue with pushing `untagged` drafts of the electron app release, passes the tag explicitly so that it is not replaced with a `hash`