### PR TITLE
Update gh actions to resolve: nodejs v20 actions are deprecated

### DIFF
--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -308,10 +308,8 @@ jobs:
         path: dist
     - name: Unzip Linux Unpacked build
       run: unzip dist/linux-unpacked.zip
-    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-        run: npm run e2e
+    - name: Run tests
+      run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Linux E2E test results
@@ -340,10 +338,8 @@ jobs:
         path: dist
     - name: Unzip Win Unpacked build
       run: 7z -y x dist/win-unpacked.zip
-    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-        run: npm run e2e
+    - name: Run tests
+      run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Win E2E test results
@@ -374,10 +370,8 @@ jobs:
         path: dist
     - name: Unzip Mac Unpacked build
       run: unzip dist/mac.zip
-    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
-      uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
-      with:
-        run: npm run e2e
+    - name: Run tests
+      run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Mac E2E test results

--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - if: github.event.inputs.version != ''
@@ -63,7 +63,7 @@ jobs:
         fi
     - name: Cache Electron binaries
       id: electron-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.4
       env:
         cache-name: electron-cache-v1
       with:
@@ -75,7 +75,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
     - name: Build release
       id: release-builder
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4.0.0
       continue-on-error: false
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,20 +93,20 @@ jobs:
     - name: Zip Linux Unpacked build
       run: zip -r dist/linux-unpacked.zip dist/linux-unpacked
     - name: Upload Linux Unpacked build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: linux-unpacked
         path: dist/linux-unpacked.zip
     - name: Zip Win Unpacked build
       run: zip -r dist/win-unpacked.zip dist/win-unpacked
     - name: Upload Win Unpacked build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: win-unpacked
         path: dist/win-unpacked.zip
     - if: env.REPO_OWNER != github.repository_owner
       name: Upload Linux Dist Release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: linux-dist-release
         path: |
@@ -115,7 +115,7 @@ jobs:
           dist/latest-linux.yml
     - if: env.REPO_OWNER != github.repository_owner
       name: Upload Win Dist Release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: win-dist-release
         path: |
@@ -132,7 +132,7 @@ jobs:
     runs-on: macos-15-intel
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
     - if: github.event.inputs.version != ''
@@ -160,12 +160,12 @@ jobs:
         else
           echo "REPO_OWNER=${{ github.repository_owner }}" >> $GITHUB_ENV
         fi
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Cache Electron binaries
       id: electron-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5.0.4
       env:
         cache-name: electron-cache-v1
       with:
@@ -176,7 +176,7 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
     - name: Build release
       id: release-builder
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4.0.0
       continue-on-error: false
       env:
         APPLE_TEAM_ID: ${{ secrets.BFX_APPLE_TEAM_ID }}
@@ -208,13 +208,13 @@ jobs:
     - name: Zip Mac Unpacked build
       run: zip -r dist/mac.zip dist/mac
     - name: Upload Mac Unpacked build
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: mac-unpacked
         path: dist/mac.zip
     - if: env.REPO_OWNER != github.repository_owner
       name: Upload Mac Dist Release
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: mac-dist-release
         path: |
@@ -231,7 +231,7 @@ jobs:
     needs: [linux-win-docker-builder, mac-builder]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
       - name: Get release version
         id: version
         run: |
@@ -251,7 +251,7 @@ jobs:
           echo "$CONTENT" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
       - name: Update matching draft release
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9.0.0
         env:
           VERSION: ${{ steps.version.outputs.version }}
           CONTENT: ${{ steps.changelog.outputs.content }}
@@ -295,27 +295,27 @@ jobs:
     needs: [linux-win-docker-builder]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6.0.2
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Install main dev deps
-      run: npm i --development --no-audit --progress=false --force
+      run: npm ci --no-audit --force
     - name: Download Linux Unpacked build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         name: linux-unpacked
         path: dist
     - name: Unzip Linux Unpacked build
       run: unzip dist/linux-unpacked.zip
-    - name: Run tests
+    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Linux E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: linux-e2e-test-results
         path: e2e-test-report.xml
@@ -327,27 +327,27 @@ jobs:
     needs: [linux-win-docker-builder]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+      uses: actions/checkout@v6.0.2
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Install main dev deps
-      run: npm i --development --no-audit --progress=false --force
+      run: npm ci --no-audit --force
     - name: Download Linux Unpacked build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         name: win-unpacked
         path: dist
     - name: Unzip Win Unpacked build
       run: 7z -y x dist/win-unpacked.zip
-    - name: Run tests
+    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Win E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: win-e2e-test-results
         path: e2e-test-report.xml
@@ -359,29 +359,29 @@ jobs:
     needs: [mac-builder]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
     - name: Prepare Mac runner
       uses: ./.github/actions/prepare-mac-runner
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Install main dev deps
-      run: npm i --development --no-audit --progress=false --force
+      run: npm ci --no-audit --force
     - name: Download Mac Unpacked build
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         name: mac-unpacked
         path: dist
     - name: Unzip Mac Unpacked build
       run: unzip dist/mac.zip
-    - name: Run tests
+    - name: Run tests # TODO: https://webdriver.io/docs/headless-and-xvfb/
       uses: coactions/setup-xvfb@6b00cf1889f4e1d5a48635647013c0508128ee1a
       with:
         run: npm run e2e
     - name: Normalize E2E test report
       run: node ./scripts/node/normalize-e2e-test-report e2e-test-report.xml
     - name: Upload Mac E2E test results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7.0.0
       with:
         name: mac-e2e-test-results
         path: e2e-test-report.xml

--- a/.github/workflows/build-electron-app.yml
+++ b/.github/workflows/build-electron-app.yml
@@ -379,3 +379,13 @@ jobs:
       with:
         name: mac-e2e-test-results
         path: e2e-test-report.xml
+  web-page-report:
+    needs:
+      - linux-e2e-test-runner
+      - win-e2e-test-runner
+      - mac-e2e-test-runner
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+    uses: ./.github/workflows/e2e-test-report.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,25 +15,21 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@v6.3.0
       with:
         node-version: 24.14.0
     - name: Setup configs and install deps
       run: ./scripts/setup.sh -u
     - name: Run tests
-      uses: nick-fields/retry@v3
-      continue-on-error: false
-      with:
-        timeout_minutes: 20
-        retry_wait_seconds: 10
-        max_attempts: 3
-        retry_on: any
-        command: npm test -- -- --reporter=json --reporter-option output=test-report.json
-    - uses: actions/upload-artifact@v4
+      run: npm test -- -- --reporter=json --reporter-option output=test-report.json
+    - uses: actions/upload-artifact@v7.0.0
       if: success() || failure()
       with:
         name: test-results
         path: test-report.json
+  web-page-report:
+    needs: linux-test-runner
+    uses: ./.github/workflows/test-report.yml

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -19,53 +19,49 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download Linux E2E test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: linux-e2e-test-results
         path: linux-e2e-test-results
-    - uses: dorny/test-reporter@v1.8.0
+    - uses: dorny/test-reporter@v3.0.0
       id: linux-e2e-test-results
       with:
         name: Linux E2E Tests
         path: linux-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        collapsed: never
         # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
         # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
         max-annotations: 0
     - name: Download Win E2E test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: win-e2e-test-results
         path: win-e2e-test-results
-    - uses: dorny/test-reporter@v1.8.0
+    - uses: dorny/test-reporter@v3.0.0
       id: win-e2e-test-results
       with:
         name: Win E2E Tests
         path: win-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        collapsed: never
         max-annotations: 0
     - name: Download Mac E2E test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
         run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: mac-e2e-test-results
         path: mac-e2e-test-results
-    - uses: dorny/test-reporter@v1.8.0
+    - uses: dorny/test-reporter@v3.0.0
       id: mac-e2e-test-results
       with:
         name: Mac E2E Tests
         path: mac-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
+        collapsed: never
         max-annotations: 0
-    - name: E2E Test Report Summary
-      run: |
-        echo "### E2E Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
-        echo "And available at the following links for applicable OSs:" >> $GITHUB_STEP_SUMMARY
-        echo "- [Linux](${{ steps.linux-e2e-test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY
-        echo "- [Win](${{ steps.win-e2e-test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY
-        echo "- [Mac](${{ steps.mac-e2e-test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -13,7 +13,6 @@ jobs:
   e2e-web-page-report:
     name: E2E Web Page Report
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download Linux E2E test results
       uses: actions/download-artifact@v8.0.0

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -2,10 +2,7 @@ name: 'E2E Test Report'
 run-name: 'E2E Test Report: Commit ${{ github.sha }}'
 
 on:
-  workflow_run:
-    workflows: ['Build release']
-    types:
-      - completed
+  workflow_call
 
 permissions:
   contents: read
@@ -21,7 +18,6 @@ jobs:
     - name: Download Linux E2E test results
       uses: actions/download-artifact@v8.0.0
       with:
-        run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: linux-e2e-test-results
         path: linux-e2e-test-results
@@ -38,7 +34,6 @@ jobs:
     - name: Download Win E2E test results
       uses: actions/download-artifact@v8.0.0
       with:
-        run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: win-e2e-test-results
         path: win-e2e-test-results
@@ -53,7 +48,6 @@ jobs:
     - name: Download Mac E2E test results
       uses: actions/download-artifact@v8.0.0
       with:
-        run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: mac-e2e-test-results
         path: mac-e2e-test-results

--- a/.github/workflows/e2e-test-report.yml
+++ b/.github/workflows/e2e-test-report.yml
@@ -24,6 +24,7 @@ jobs:
       id: linux-e2e-test-results
       with:
         name: Linux E2E Tests
+        report-title: Linux E2E Tests
         path: linux-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
         collapsed: never
@@ -40,6 +41,7 @@ jobs:
       id: win-e2e-test-results
       with:
         name: Win E2E Tests
+        report-title: Win E2E Tests
         path: win-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
         collapsed: never
@@ -54,6 +56,7 @@ jobs:
       id: mac-e2e-test-results
       with:
         name: Mac E2E Tests
+        report-title: Mac E2E Tests
         path: mac-e2e-test-results/e2e-test-report.xml
         reporter: jest-junit
         collapsed: never

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -13,7 +13,6 @@ jobs:
   web-page-report:
     name: Web Page Report
     runs-on: ubuntu-22.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download test results
       uses: actions/download-artifact@v8.0.0

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -2,10 +2,7 @@ name: 'Test Report'
 run-name: 'Test Report: Commit ${{ github.sha }}'
 
 on:
-  workflow_run:
-    workflows: ['CI']
-    types:
-      - completed
+  workflow_call
 
 permissions:
   contents: read
@@ -19,22 +16,18 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - name: Download test results
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8.0.0
       with:
-        run-id: ${{ github.event.workflow_run.id }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
         name: test-results
         path: test-results
-    - uses: dorny/test-reporter@v1.8.0
+    - uses: dorny/test-reporter@v3.0.0
       id: test-results
       with:
         name: Mocha Tests
         path: test-results/test-report.json
         reporter: mocha-json
+        collapsed: never
         # Workaround for error 'fatal: not a git repository' caused by a call to 'git ls-files'
         # See: https://github.com/dorny/test-reporter/issues/169#issuecomment-1583560458
         max-annotations: 0
-    - name: Test Report Summary
-      run: |
-        echo "### Test Report page is ready! :rocket:" >> $GITHUB_STEP_SUMMARY
-        echo "And available at the following [Link](${{ steps.test-results.outputs.url_html }})" >> $GITHUB_STEP_SUMMARY

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "electron-chromedriver": "40.8.2",
         "eslint": "8.57.0",
         "eslint-config-standard": "17.1.0",
+        "fast-xml-parser": "5.5.12",
         "mocha": "11.1.0",
         "standard": "17.1.2"
       },
@@ -7789,9 +7790,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.5.9",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.9.tgz",
-      "integrity": "sha512-jldvxr1MC6rtiZKgrFnDSvT8xuH+eJqxqOBThUVjYrxssYTo1avZLGql5l0a0BAERR01CadYzZ83kVEkbyDg+g==",
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.12.tgz",
+      "integrity": "sha512-nUR0q8PPfoA/svPM43Gup7vLOZWppaNrYgGmrVqrAVJa7cOH4hMG6FX9M4mQ8dZA1/ObGZHzES7Ed88hxEBSJg==",
       "dev": true,
       "funding": [
         {
@@ -7802,8 +7803,8 @@
       "license": "MIT",
       "dependencies": {
         "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.2.0",
-        "strnum": "^2.2.2"
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -12332,9 +12333,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "dev": true,
       "funding": [
         {
@@ -15087,9 +15088,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
-      "integrity": "sha512-DnR90I+jtXNSTXWdwrEy9FakW7UX+qUZg28gj5fk2vxxl7uS/3bpI4fjFYVmdK9etptYBPNkpahuQnEwhwECqA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "electron-chromedriver": "40.8.2",
     "eslint": "8.57.0",
     "eslint-config-standard": "17.1.0",
+    "fast-xml-parser": "5.5.12",
     "mocha": "11.1.0",
     "standard": "17.1.2"
   },

--- a/scripts/node/normalize-e2e-test-report.js
+++ b/scripts/node/normalize-e2e-test-report.js
@@ -1,20 +1,54 @@
 'use strict'
 
-const path = require('path')
+const path = require('node:path')
 const {
   readFileSync,
   writeFileSync
-} = require('fs')
+} = require('node:fs')
+const {
+  XMLParser,
+  XMLBuilder
+} = require('fast-xml-parser')
 
 const cwd = process.cwd()
 const fileName = process.argv[2]
 const filePath = path.join(cwd, fileName)
 
-const content = readFileSync(filePath, { encoding: 'utf8' })
+const reportXML = readFileSync(filePath, { encoding: 'utf8' })
+
+const opts = {
+  ignoreAttributes: false,
+  allowBooleanAttributes: true,
+  attributeNamePrefix: 'attr_',
+  cdataPropName: '__cdata',
+  format: true,
+  unpairedTags: 'property',
+  suppressUnpairedNode: false
+}
+const parser = new XMLParser(opts)
+const reportObj = parser.parse(reportXML)
+
 /*
  * For compatibility with the dorny/test-reporter,
  * there needs to be 'time' attribute to '<testsuites>' tag
  */
-const normalizedContent = content
-  .replace(/<testsuites>/gi, '<testsuites time="0">')
-writeFileSync(filePath, normalizedContent)
+const testsuites = Array.isArray(reportObj.testsuites.testsuite)
+  ? reportObj.testsuites.testsuite
+  : [reportObj.testsuites.testsuite]
+const totalTime = testsuites.reduce((accum, curr) => {
+  if (!curr?.attr_time) {
+    return accum
+  }
+
+  const time = Number.parseFloat(curr.attr_time)
+
+  return Number.isFinite(time)
+    ? accum + time
+    : accum
+}, 0)
+reportObj.testsuites.attr_time = totalTime
+
+const builder = new XMLBuilder(opts)
+const outputXML = builder.build(reportObj)
+
+writeFileSync(filePath, outputXML)

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -132,7 +132,7 @@ exports.config = {
   baseUrl: '',
   //
   // Default timeout for all waitFor* commands.
-  waitforTimeout: 20_000,
+  waitforTimeout: 60_000,
   //
   // Default timeout in milliseconds for request
   // if browser driver or grid doesn't send response
@@ -182,7 +182,7 @@ exports.config = {
   // See the full list at http://mochajs.org/
   mochaOpts: {
     ui: 'bdd',
-    timeout: 60000
+    timeout: 3 * 60_000
   }
 
   //

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -19,6 +19,11 @@ const getAppBinaryPath = () => {
 }
 
 exports.config = {
+  // Use Xvfb when needed
+  // https://webdriver.io/docs/headless-and-xvfb/
+  autoXvfb: true,
+  // Auto-install Xvfb packages
+  xvfbAutoInstall: true,
   //
   // ====================
   // Runner Configuration


### PR DESCRIPTION
This PR updates GH Actions to resolve GH warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/download-artifact@v4, dorny/test-reporter@v1.8.0. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24

---

Basic changes:
- Updates GH Actions to resolve GH warning
- Enhances headless and xvfb usage for e2e testrunner
- Reworks e2e test report generation
- Adds e2e test report titles for platform definition
- Increase e2e timeout to resolve issue on mac when gh servers are slow
- Implements total e2e time calc for test-reporter compatibility, there needs to be `time` attribute to '<testsuites>' tag with total calced time of all suitecases

---

Tested here:
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/24399209116
- https://github.com/ZIMkaRU/bfx-report-electron/actions/runs/24339737191
