### PR TITLE
Enhance changelog item initialization

### DIFF
--- a/src/changelog-manager/index.js
+++ b/src/changelog-manager/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
+const initChangelog = require('./init-changelog')
 const showChangelog = require('./show-changelog')
 
 module.exports = {
+  initChangelog,
   showChangelog
 }

--- a/src/changelog-manager/init-changelog.js
+++ b/src/changelog-manager/init-changelog.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const path = require('node:path')
+const fs = require('node:fs')
+const parseChangelog = require('changelog-parser')
+
+const getDebugInfo = require('../helpers/get-debug-info')
+const MENU_ITEM_IDS = require('../create-menu/menu.item.ids')
+const { changeMenuItemStatesById } = require('../create-menu/utils')
+const { rootPath } = require('../helpers/root-path')
+
+const changelogPath = path.join(rootPath, 'CHANGELOG.md')
+const changelog = fs.readFileSync(changelogPath, 'utf8')
+
+let mdEntries = null
+
+const disableShowChangelogMenuItem = () => {
+  changeMenuItemStatesById(
+    MENU_ITEM_IDS.SHOW_CHANGE_LOG_MENU_ITEM,
+    { enabled: false }
+  )
+}
+
+module.exports = async (params) => {
+  const version = params?.version ?? getDebugInfo()?.version
+
+  mdEntries = mdEntries ?? await parseChangelog({
+    text: changelog,
+    removeMarkdown: false
+  })
+
+  if (
+    !mdEntries?.title ||
+    !Array.isArray(mdEntries?.versions) ||
+    mdEntries?.versions.length === 0
+  ) {
+    disableShowChangelogMenuItem()
+
+    return {
+      shouldBeShown: false,
+      version,
+      changelog,
+      mdEntries,
+      mdEntry: null
+    }
+  }
+
+  const mdEntry = mdEntries.versions
+    .find((item) => item?.version === version)
+  const shouldBeShown = (
+    mdEntry?.title &&
+    mdEntry?.body
+  )
+
+  if (!shouldBeShown) {
+    disableShowChangelogMenuItem()
+  }
+
+  return {
+    shouldBeShown,
+    version,
+    changelog,
+    mdEntries,
+    mdEntry
+  }
+}

--- a/src/changelog-manager/show-changelog.js
+++ b/src/changelog-manager/show-changelog.js
@@ -1,58 +1,21 @@
 'use strict'
 
-const path = require('path')
-const fs = require('fs')
-const parseChangelog = require('changelog-parser')
 const i18next = require('i18next')
 
-const { rootPath } = require('../helpers/root-path')
-const getDebugInfo = require('../helpers/get-debug-info')
 const showDocs = require('../show-docs')
-
-const MENU_ITEM_IDS = require('../create-menu/menu.item.ids')
-const { changeMenuItemStatesById } = require('../create-menu/utils')
-
-const changelogPath = path.join(rootPath, 'CHANGELOG.md')
-const changelog = fs.readFileSync(changelogPath, 'utf8')
-
-const disableShowChangelogMenuItem = () => {
-  changeMenuItemStatesById(
-    MENU_ITEM_IDS.SHOW_CHANGE_LOG_MENU_ITEM,
-    { enabled: false }
-  )
-}
+const initChangelog = require('./init-changelog')
 
 module.exports = async (params = {}) => {
   try {
-    const version = params?.version ?? getDebugInfo()?.version
+    const {
+      shouldBeShown,
+      version,
+      changelog,
+      mdEntries,
+      mdEntry
+    } = await initChangelog(params)
 
-    const mdEntries = await parseChangelog({
-      text: changelog,
-      removeMarkdown: false
-    })
-
-    if (
-      !mdEntries?.title ||
-      !Array.isArray(mdEntries?.versions) ||
-      mdEntries?.versions.length === 0
-    ) {
-      disableShowChangelogMenuItem()
-
-      return {
-        error: null,
-        isShown: false
-      }
-    }
-
-    const mdEntry = mdEntries.versions
-      .find((item) => item?.version === version)
-
-    if (
-      !mdEntry?.title ||
-      !mdEntry?.body
-    ) {
-      disableShowChangelogMenuItem()
-
+    if (!shouldBeShown) {
       return {
         error: null,
         isShown: false

--- a/src/create-menu/index.js
+++ b/src/create-menu/index.js
@@ -20,7 +20,10 @@ const {
 } = require('../auto-updater')
 const { manageNewGithubIssue } = require('../error-manager')
 const showDocs = require('../show-docs')
-const { showChangelog } = require('../changelog-manager')
+const {
+  initChangelog,
+  showChangelog
+} = require('../changelog-manager')
 const parseEnvValToBool = require('../helpers/parse-env-val-to-bool')
 const isMainWinAvailable = require('../helpers/is-main-win-available')
 const {
@@ -70,7 +73,7 @@ const _getPrevMenuItemPropsById = (id, params) => {
   return res
 }
 
-module.exports = (params) => {
+module.exports = async (params) => {
   pathToUserData = params?.pathToUserData ?? pathToUserData
   pathToUserDocuments = params?.pathToUserDocuments ?? pathToUserDocuments
 
@@ -506,5 +509,6 @@ module.exports = (params) => {
   ]
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate))
+  await initChangelog()
   isMenuInitialized = true
 }

--- a/src/window-creators/index.js
+++ b/src/window-creators/index.js
@@ -421,7 +421,7 @@ const createMainWindow = async ({
       .setTitle(`${title} - BFX API STAGING USED`)
   }
 
-  createMenu({
+  await createMenu({
     pathToUserData,
     pathToUserDocuments: IS_MAC
       ? pathToUserDownloads

--- a/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
+++ b/src/window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers.js
@@ -25,7 +25,7 @@ class TranslationIpcChannelHandlers extends IpcChannelHandlers {
     const language = i18next.resolvedLanguage
 
     if (prevLanguage !== language) {
-      createMenu()
+      await createMenu()
     }
 
     const configsKeeper = getConfigsKeeperByName()


### PR DESCRIPTION
This PR enhances changelog menu item initialization as ui has the implemented capability for it: added ability to refetch Electron menu states and rerender https://github.com/bitfinexcom/bfx-report-ui/pull/1072
If a changelog is available for the corresponding app version, show the menu item as active, otherwise as inactive

<img width="534" height="223" alt="Screenshot from 2026-05-11 11-09-17" src="https://github.com/user-attachments/assets/b0b8a312-63d3-4ffe-88dd-4b62e84f1c19" />

