### PR TITLE
Set desktopName in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "bfx-report-electron",
   "version": "4.46.1",
   "repository": "https://github.com/bitfinexcom/bfx-report-electron",
+  "desktopName": "com.bitfinex.report",
   "description": "Reporting tool",
   "author": "bitfinex.com",
   "main": "index.js",


### PR DESCRIPTION
This PR sets `desktopName` in `package.json` to fix an important warning when building the app with the `electron-builder` tool; see doc: https://www.electron.build/docs/linux/#window-association-desktopname

---

Warning in building logs:
```console
linux-builder | • electron uses desktopName as app_id / WM_CLASS for window association. Without it desktop environments may not link running windows to this .desktop entry. Set desktopName in package.json and linux.syncDesktopName: true to fix. reason=desktopName is not set in package.json docs=https://www.electron.build/linux#window-association-desktopname--syncdesktopname
```

Tested with this beta release:
- https://github.com/ZIMkaRU/bfx-report-electron/releases/tag/v4.47.0-beta.5
