### PR TITLE
Simplify ipc channel handlers init

### DIFF
--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -7,8 +7,7 @@ const {
   serializeError,
   deserializeError,
   rm,
-  getServerPromise,
-  initIpcChannelHandlers
+  getServerPromise
 } = require('./utils')
 const isMainWinAvailable = require(
   './is-main-win-available'
@@ -32,7 +31,6 @@ module.exports = {
   deserializeError,
   rm,
   getServerPromise,
-  initIpcChannelHandlers,
   isMainWinAvailable,
   productName,
   getAlertCustomClassObj,

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -98,16 +98,9 @@ const getServerPromise = (srv, port) => {
   })
 }
 
-const initIpcChannelHandlers = (...ipcChannelHandlersList) => {
-  for (const IpcChannelHandlers of ipcChannelHandlersList) {
-    IpcChannelHandlers.create()
-  }
-}
-
 module.exports = {
   serializeError,
   deserializeError,
   rm,
-  getServerPromise,
-  initIpcChannelHandlers
+  getServerPromise
 }

--- a/src/initialize-app.js
+++ b/src/initialize-app.js
@@ -3,26 +3,8 @@
 const { app } = require('electron')
 const i18next = require('i18next')
 
-const TranslationIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/translation-ipc-channel-handlers'
-)
-const GeneralIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/general-ipc-channel-handlers'
-)
-const MenuIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/menu-ipc-channel-handlers'
-)
-const ThemeIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/theme-ipc-channel-handlers'
-)
-const AutoUpdateIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/auto-update-ipc-channel-handlers'
-)
-const ModalIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/modal-ipc-channel-handlers'
-)
-const ReportExportIpcChannelHandlers = require(
-  './window-creators/main-renderer-ipc-bridge/report-export-ipc-channel-handlers'
+const { initIpcChannelHandlers } = require(
+  './window-creators/main-renderer-ipc-bridge/utils'
 )
 const triggerSyncAfterUpdates = require('./trigger-sync-after-updates')
 const triggerElectronLoad = require('./trigger-electron-load')
@@ -43,7 +25,6 @@ const {
 const {
   deserializeError,
   getFreePort,
-  initIpcChannelHandlers,
   manageConfigs,
   platformIdentifiers: {
     IS_WIN
@@ -115,15 +96,9 @@ const _ipcMessToPromise = (ipc) => {
 
 module.exports = async () => {
   try {
-    initIpcChannelHandlers(
-      GeneralIpcChannelHandlers,
-      TranslationIpcChannelHandlers,
-      MenuIpcChannelHandlers,
-      ThemeIpcChannelHandlers,
-      AutoUpdateIpcChannelHandlers,
-      ModalIpcChannelHandlers,
-      ReportExportIpcChannelHandlers
-    )
+    const {
+      ThemeIpcChannelHandlers
+    } = initIpcChannelHandlers()
 
     app.disableHardwareAcceleration()
     app.on('window-all-closed', () => {

--- a/src/window-creators/main-renderer-ipc-bridge/index.js
+++ b/src/window-creators/main-renderer-ipc-bridge/index.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const TranslationIpcChannelHandlers = require(
+  './translation-ipc-channel-handlers'
+)
+const GeneralIpcChannelHandlers = require(
+  './general-ipc-channel-handlers'
+)
+const MenuIpcChannelHandlers = require(
+  './menu-ipc-channel-handlers'
+)
+const ThemeIpcChannelHandlers = require(
+  './theme-ipc-channel-handlers'
+)
+const AutoUpdateIpcChannelHandlers = require(
+  './auto-update-ipc-channel-handlers'
+)
+const ModalIpcChannelHandlers = require(
+  './modal-ipc-channel-handlers'
+)
+const ReportExportIpcChannelHandlers = require(
+  './report-export-ipc-channel-handlers'
+)
+
+module.exports = {
+  GeneralIpcChannelHandlers,
+  TranslationIpcChannelHandlers,
+  MenuIpcChannelHandlers,
+  ThemeIpcChannelHandlers,
+  AutoUpdateIpcChannelHandlers,
+  ModalIpcChannelHandlers,
+  ReportExportIpcChannelHandlers
+}

--- a/src/window-creators/main-renderer-ipc-bridge/utils/index.js
+++ b/src/window-creators/main-renderer-ipc-bridge/utils/index.js
@@ -1,0 +1,25 @@
+'use strict'
+
+const mainRendererIpcBridge = require('..')
+
+let isInited = false
+
+const initIpcChannelHandlers = () => {
+  if (isInited) {
+    return mainRendererIpcBridge
+  }
+
+  const IpcChannelHandlersList = Object.values(mainRendererIpcBridge)
+
+  for (const IpcChannelHandlers of IpcChannelHandlersList) {
+    IpcChannelHandlers.create()
+  }
+
+  isInited = true
+
+  return mainRendererIpcBridge
+}
+
+module.exports = {
+  initIpcChannelHandlers
+}


### PR DESCRIPTION
This PR brings refactoring to simplify the ipc-channel-handlers init due to the increase in their number

---

Depends on this PR:
- https://github.com/bitfinexcom/bfx-report-electron/pull/644
